### PR TITLE
chore: per-reviewer GATE_RESULT logging and execution state change tracking

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -244,14 +244,7 @@ export class Runner {
 
 		this.results.push(result);
 		this.reporter.onJobComplete(job, result);
-
-		// Log gate result
-		await this.debugLogger?.logGateResult(
-			job.id,
-			result.status,
-			result.duration,
-			result.errorCount,
-		);
+		await this.logGateResults(job.id, result);
 
 		// Handle Fail Fast (only for checks, and only when parallel is false)
 		if (
@@ -260,6 +253,37 @@ export class Runner {
 			job.gateConfig.fail_fast
 		) {
 			this.shouldStop = true;
+		}
+	}
+
+	/**
+	 * Log gate results to the debug log.
+	 * For review gates with subResults, logs one entry per reviewer.
+	 * For check gates, logs a single entry.
+	 */
+	private async logGateResults(
+		jobId: string,
+		result: GateResult,
+	): Promise<void> {
+		if (!this.debugLogger) return;
+
+		if (result.subResults && result.subResults.length > 0) {
+			for (const sub of result.subResults) {
+				const cli = sub.nameSuffix.match(/\((.+?)@\d+\)/)?.[1];
+				await this.debugLogger.logGateResult(
+					jobId,
+					sub.status,
+					sub.duration ?? result.duration,
+					{ violations: sub.errorCount, cli },
+				);
+			}
+		} else {
+			await this.debugLogger.logGateResult(
+				jobId,
+				result.status,
+				result.duration,
+				{ violations: result.errorCount },
+			);
 		}
 	}
 }

--- a/src/gates/result.ts
+++ b/src/gates/result.ts
@@ -39,6 +39,7 @@ export interface GateResult {
 	subResults?: Array<{
 		nameSuffix: string;
 		status: GateStatus;
+		duration?: number; // per-reviewer timing in ms
 		message: string;
 		logPath?: string;
 		errorCount?: number;

--- a/src/gates/review.ts
+++ b/src/gates/review.ts
@@ -203,6 +203,7 @@ export class ReviewGateExecutor {
 			const outputs: Array<{
 				adapter: string;
 				reviewIndex: number;
+				duration?: number;
 				status: "pass" | "fail" | "error";
 				message: string;
 				json?: ReviewJsonOutput;
@@ -442,6 +443,7 @@ export class ReviewGateExecutor {
 						outputs.push({
 							adapter: res.adapter,
 							reviewIndex: res.reviewIndex,
+							duration: res.duration,
 							...res.evaluation,
 						});
 					}
@@ -465,6 +467,7 @@ export class ReviewGateExecutor {
 						outputs.push({
 							adapter: res.adapter,
 							reviewIndex: res.reviewIndex,
+							duration: res.duration,
 							...res.evaluation,
 						});
 					}
@@ -534,6 +537,7 @@ export class ReviewGateExecutor {
 				return {
 					nameSuffix: `(${out.adapter}@${out.reviewIndex})`,
 					status: out.status,
+					duration: out.duration,
 					message: out.message,
 					logPath,
 					errorCount,
@@ -555,9 +559,11 @@ export class ReviewGateExecutor {
 				subResults.push({
 					nameSuffix: `(${skipped.adapter}@${skipped.reviewIndex})`,
 					status: "pass" as const, // Show as pass since it previously passed
+					duration: undefined,
 					message: skipped.message,
 					logPath: specificLog?.replace(/\.log$/, ".json"),
 					errorCount: 0,
+					fixedCount: 0,
 					skipped: undefined,
 				});
 			}
@@ -622,6 +628,7 @@ export class ReviewGateExecutor {
 	): Promise<{
 		adapter: string;
 		reviewIndex: number;
+		duration: number;
 		evaluation: {
 			status: "pass" | "fail" | "error";
 			message: string;
@@ -634,6 +641,7 @@ export class ReviewGateExecutor {
 			}>;
 		};
 	} | null> {
+		const reviewStartTime = Date.now();
 		const adapter = getAdapter(toolName);
 		if (!adapter) return null;
 
@@ -696,6 +704,7 @@ export class ReviewGateExecutor {
 				return {
 					adapter: adapter.name,
 					reviewIndex,
+					duration: Date.now() - reviewStartTime,
 					evaluation: {
 						status: "error",
 						message: reason,
@@ -835,6 +844,7 @@ export class ReviewGateExecutor {
 			return {
 				adapter: adapter.name,
 				reviewIndex,
+				duration: Date.now() - reviewStartTime,
 				evaluation: {
 					status: evaluation.status,
 					message: evaluation.message,
@@ -864,6 +874,7 @@ export class ReviewGateExecutor {
 				return {
 					adapter: adapter.name,
 					reviewIndex,
+					duration: Date.now() - reviewStartTime,
 					evaluation: {
 						status: "error",
 						message: reason,

--- a/src/utils/debug-log.ts
+++ b/src/utils/debug-log.ts
@@ -133,18 +133,20 @@ export class DebugLogger {
 
 	/**
 	 * Log the result of a gate execution.
+	 * When `cli` is provided, the adapter name is included in the log entry.
 	 */
 	async logGateResult(
 		gateId: string,
 		status: string,
 		duration: number,
-		violations?: number,
+		opts?: { violations?: number; cli?: string },
 	): Promise<void> {
 		const durationStr = `${(duration / 1000).toFixed(1)}s`;
+		const cliStr = opts?.cli ? ` cli=${opts.cli}` : "";
 		const violationsStr =
-			violations !== undefined ? ` violations=${violations}` : "";
+			opts?.violations !== undefined ? ` violations=${opts.violations}` : "";
 		await this.write(
-			`GATE_RESULT ${gateId} status=${status} duration=${durationStr}${violationsStr}`,
+			`GATE_RESULT ${gateId}${cliStr} status=${status} duration=${durationStr}${violationsStr}`,
 		);
 	}
 
@@ -227,6 +229,44 @@ export class DebugLogger {
 		await this.write(
 			`STOP_HOOK_EARLY_EXIT source=${source} status=${status}${detailStr}`,
 		);
+	}
+
+	/**
+	 * Log an execution state write, showing only changed fields.
+	 * Skips `last_run_completed_at` since every log line is already timestamped.
+	 */
+	async logStateWrite(changes: Record<string, string>): Promise<void> {
+		const parts = Object.entries(changes).map(
+			([key, value]) => `${key}=${value}`,
+		);
+		await this.write(
+			`STATE_WRITE${parts.length > 0 ? ` ${parts.join(" ")}` : ""}`,
+		);
+	}
+
+	/**
+	 * Log an execution state deletion.
+	 */
+	async logStateDelete(): Promise<void> {
+		await this.write("STATE_DELETE");
+	}
+
+	/**
+	 * Log an adapter health change.
+	 */
+	async logAdapterHealthChange(
+		adapter: string,
+		healthy: boolean,
+		reason?: string,
+	): Promise<void> {
+		if (healthy) {
+			await this.write(`STATE_ADAPTER_HEALTHY adapter=${adapter}`);
+		} else {
+			const reasonStr = reason ? ` reason=${reason}` : "";
+			await this.write(
+				`STATE_ADAPTER_UNHEALTHY adapter=${adapter}${reasonStr}`,
+			);
+		}
 	}
 
 	/**

--- a/src/utils/execution-state.ts
+++ b/src/utils/execution-state.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { getDebugLogger } from "./debug-log.js";
 
 const EXECUTION_STATE_FILENAME = ".execution_state";
 const SESSION_REF_FILENAME = ".session_ref";
@@ -162,6 +163,22 @@ export async function writeExecutionState(logDir: string): Promise<void> {
 	if (existingUnhealthy) {
 		state.unhealthy_adapters = existingUnhealthy;
 	}
+
+	// Log changed fields (skip last_run_completed_at since every log line is timestamped)
+	const changes: Record<string, string> = {};
+	const oldState = rawState as Record<string, unknown> | null;
+	if (oldState) {
+		if (oldState.branch !== branch) changes.branch = branch;
+		if (oldState.commit !== commit) changes.commit = commit;
+		if (oldState.working_tree_ref !== workingTreeRef)
+			changes.working_tree_ref = workingTreeRef;
+	} else {
+		// First write - log all fields
+		changes.branch = branch;
+		changes.commit = commit;
+		changes.working_tree_ref = workingTreeRef;
+	}
+	await getDebugLogger()?.logStateWrite(changes);
 
 	// Ensure the log directory exists
 	await fs.mkdir(logDir, { recursive: true });
@@ -394,6 +411,8 @@ export async function markAdapterUnhealthy(
 	adapterName: string,
 	reason: string,
 ): Promise<void> {
+	await getDebugLogger()?.logAdapterHealthChange(adapterName, false, reason);
+
 	const statePath = path.join(logDir, EXECUTION_STATE_FILENAME);
 	const rawData = (await readRawState(statePath)) ?? {};
 
@@ -417,6 +436,8 @@ export async function markAdapterHealthy(
 	logDir: string,
 	adapterName: string,
 ): Promise<void> {
+	await getDebugLogger()?.logAdapterHealthChange(adapterName, true);
+
 	const statePath = path.join(logDir, EXECUTION_STATE_FILENAME);
 	const rawData = await readRawState(statePath);
 	if (!rawData) return;
@@ -442,6 +463,7 @@ export async function markAdapterHealthy(
  */
 export async function deleteExecutionState(logDir: string): Promise<void> {
 	try {
+		await getDebugLogger()?.logStateDelete();
 		const statePath = path.join(logDir, EXECUTION_STATE_FILENAME);
 		await fs.rm(statePath, { force: true });
 	} catch {

--- a/test/utils/debug-log.test.ts
+++ b/test/utils/debug-log.test.ts
@@ -56,6 +56,19 @@ describe("DebugLogger", () => {
 	});
 
 	describe("logging methods", () => {
+		/** Create an enabled logger and return a content reader. */
+		function createTestLogger() {
+			const logger = new DebugLogger(TEST_DIR, {
+				enabled: true,
+				maxSizeMb: 10,
+			});
+			const readLog = async () => {
+				const logPath = path.join(TEST_DIR, ".debug.log");
+				return fs.readFile(logPath, "utf-8");
+			};
+			return { logger, readLog };
+		}
+
 		it("does not write when disabled", async () => {
 			const logger = new DebugLogger(TEST_DIR, {
 				enabled: false,
@@ -68,34 +81,21 @@ describe("DebugLogger", () => {
 		});
 
 		it("writes log entries when enabled", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logCommand("run", ["-b", "main"]);
-
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
-			expect(content).toContain("COMMAND run -b main");
+			expect(await readLog()).toContain("COMMAND run -b main");
 		});
 
 		it("writes RUN_START entries", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logRunStart("full", 5, 3);
-
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
-			expect(content).toContain("RUN_START mode=full changes=5 gates=3");
+			expect(await readLog()).toContain(
+				"RUN_START mode=full changes=5 gates=3",
+			);
 		});
 
 		it("writes RUN_START with diff stats - branch ref", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logRunStartWithDiff(
 				"full",
 				{
@@ -110,8 +110,7 @@ describe("DebugLogger", () => {
 				4,
 			);
 
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
+			const content = await readLog();
 			expect(content).toContain("RUN_START mode=full");
 			expect(content).toContain("base_ref=origin/main");
 			expect(content).toContain("files_changed=10");
@@ -124,10 +123,7 @@ describe("DebugLogger", () => {
 		});
 
 		it("writes RUN_START with diff stats - commit SHA", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logRunStartWithDiff(
 				"verification",
 				{
@@ -142,17 +138,13 @@ describe("DebugLogger", () => {
 				1,
 			);
 
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
+			const content = await readLog();
 			expect(content).toContain("mode=verification");
 			expect(content).toContain("base_ref=abc123def456");
 		});
 
 		it("writes RUN_START with diff stats - uncommitted", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logRunStartWithDiff(
 				"full",
 				{
@@ -166,17 +158,11 @@ describe("DebugLogger", () => {
 				},
 				2,
 			);
-
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
-			expect(content).toContain("base_ref=uncommitted");
+			expect(await readLog()).toContain("base_ref=uncommitted");
 		});
 
 		it("writes RUN_START with diff stats - worktree ref", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logRunStartWithDiff(
 				"verification",
 				{
@@ -190,76 +176,117 @@ describe("DebugLogger", () => {
 				},
 				1,
 			);
-
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
-			expect(content).toContain("base_ref=WORKTREE-abc123");
+			expect(await readLog()).toContain("base_ref=WORKTREE-abc123");
 		});
 
 		it("writes RUN_END entries with duration", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logRunStart("full", 5, 3);
 			await logger.logRunEnd("pass", 2, 1, 0, 1);
-
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
-			expect(content).toContain(
+			expect(await readLog()).toContain(
 				"RUN_END status=pass fixed=2 skipped=1 failed=0 iterations=1 duration=",
 			);
 		});
 
 		it("writes GATE_RESULT entries", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
+			const { logger, readLog } = createTestLogger();
+			await logger.logGateResult("check:src:lint", "pass", 1234, {
+				violations: 0,
 			});
-			await logger.logGateResult("check:src:lint", "pass", 1234, 0);
 
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
+			const content = await readLog();
 			expect(content).toContain("GATE_RESULT check:src:lint status=pass");
 			expect(content).toContain("duration=");
 			expect(content).toContain("violations=0");
 		});
 
-		it("writes CLEAN entries", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
+		it("writes GATE_RESULT entries with cli adapter name", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logGateResult("review:.:code-quality", "fail", 107700, {
+				violations: 3,
+				cli: "gemini",
 			});
-			await logger.logClean("auto", "all_passed");
+			expect(await readLog()).toContain(
+				"GATE_RESULT review:.:code-quality cli=gemini status=fail duration=107.7s violations=3",
+			);
+		});
 
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
-			expect(content).toContain("CLEAN type=auto reason=all_passed");
+		it("writes GATE_RESULT entries without cli when not provided", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logGateResult("check:src:build", "pass", 5000);
+
+			const content = await readLog();
+			expect(content).toContain(
+				"GATE_RESULT check:src:build status=pass duration=5.0s",
+			);
+			expect(content).not.toContain("cli=");
+		});
+
+		it("writes CLEAN entries", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logClean("auto", "all_passed");
+			expect(await readLog()).toContain("CLEAN type=auto reason=all_passed");
 		});
 
 		it("writes STOP_HOOK entries", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logStopHook("allow", "passed");
+			expect(await readLog()).toContain(
+				"STOP_HOOK decision=allow reason=passed",
+			);
+		});
 
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
-			expect(content).toContain("STOP_HOOK decision=allow reason=passed");
+		it("writes STATE_WRITE with changed fields", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logStateWrite({
+				commit: "def456",
+				branch: "main",
+				working_tree_ref: "abc789",
+			});
+			expect(await readLog()).toContain(
+				"STATE_WRITE commit=def456 branch=main working_tree_ref=abc789",
+			);
+		});
+
+		it("writes STATE_WRITE with no fields for timestamp-only refresh", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logStateWrite({});
+			expect(await readLog()).toContain("STATE_WRITE\n");
+		});
+
+		it("writes STATE_DELETE", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logStateDelete();
+			expect(await readLog()).toContain("STATE_DELETE");
+		});
+
+		it("writes STATE_ADAPTER_UNHEALTHY with reason", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logAdapterHealthChange(
+				"gemini",
+				false,
+				"Usage limit exceeded",
+			);
+			expect(await readLog()).toContain(
+				"STATE_ADAPTER_UNHEALTHY adapter=gemini reason=Usage limit exceeded",
+			);
+		});
+
+		it("writes STATE_ADAPTER_HEALTHY", async () => {
+			const { logger, readLog } = createTestLogger();
+			await logger.logAdapterHealthChange("gemini", true);
+			expect(await readLog()).toContain(
+				"STATE_ADAPTER_HEALTHY adapter=gemini",
+			);
 		});
 
 		it("includes timestamp in log entries", async () => {
-			const logger = new DebugLogger(TEST_DIR, {
-				enabled: true,
-				maxSizeMb: 10,
-			});
+			const { logger, readLog } = createTestLogger();
 			await logger.logCommand("test", []);
-
-			const logPath = path.join(TEST_DIR, ".debug.log");
-			const content = await fs.readFile(logPath, "utf-8");
 			// Should have ISO timestamp format
-			expect(content).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+			expect(await readLog()).toMatch(
+				/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+			);
 		});
 	});
 


### PR DESCRIPTION
## Summary

- **Per-reviewer debug logging**: For review gates with multiple adapters, log one `GATE_RESULT` entry per reviewer with the CLI adapter name and individual timing (e.g. `GATE_RESULT review:.:code-quality cli=gemini status=fail duration=107.7s`). Check gates retain the existing single-entry behavior.
- **Duration tracking in sub-results**: Add `duration` field to `GateResult.subResults` and track per-reviewer timing in `runSingleReview()`.
- **Execution state change logging**: Add `STATE_WRITE`, `STATE_DELETE`, `STATE_ADAPTER_UNHEALTHY`, and `STATE_ADAPTER_HEALTHY` debug log entries at execution state mutation points, showing only changed fields (skipping `last_run_completed_at` since log lines are already timestamped).

## Changes

| File | What changed |
|------|-------------|
| `src/gates/result.ts` | Added `duration?: number` to `subResults` type |
| `src/gates/review.ts` | Track `reviewStartTime` in `runSingleReview()`, propagate duration through outputs to subResults |
| `src/utils/debug-log.ts` | `logGateResult` now accepts `opts?: { violations?, cli? }` (was positional args). Added `logStateWrite()`, `logStateDelete()`, `logAdapterHealthChange()` |
| `src/core/runner.ts` | Per-reviewer logging loop for review gates, extracted `logGateResults()` helper to reduce `executeJob` complexity |
| `src/utils/execution-state.ts` | Integrated debug logging into `writeExecutionState`, `deleteExecutionState`, `markAdapterUnhealthy`, `markAdapterHealthy` |
| `test/utils/debug-log.test.ts` | Added tests for new methods, DRYed up with `createTestLogger` helper |

## Test plan

- [x] All 25 debug-log tests pass (including 7 new tests)
- [x] All 43 execution-state tests pass
- [x] Full gauntlet passes (build, lint, test, security, code-health, schema-validate, code-quality review)

Made with [Cursor](https://cursor.com)