### PR TITLE
fix: remove redundant comment on buildHelpSkillBundle

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -181,7 +181,6 @@ Combine the script's session summary with the detailed failure information into 
  * Build the gauntlet-help skill bundle content.
  * Returns { content, references } for the multi-file skill.
  */
-// Builds the full gauntlet-help skill bundle (SKILL.md + reference files)
 function buildHelpSkillBundle(): {
 	content: string;
 	references: Record<string, string>;


### PR DESCRIPTION
## Summary

- Remove duplicate inline comment on `buildHelpSkillBundle()` — the JSDoc block already describes the function. Flagged by CodeRabbit on PR #41 (merged before this fix was pushed).

## Context

This was the remaining fix from PR #41's CodeRabbit review. The telemetry stdout→stderr fix was included in the merged commit; this comment cleanup was in a follow-up commit that didn't make it in.

## Test plan

- [x] Lint passes
- [x] All 571 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code cleanup with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->