### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-gauntlet
 
+## 0.11.0
+
+### Minor Changes
+
+- [#50](https://github.com/pacaplan/agent-gauntlet/pull/50) Remove Bun runtime requirement for end users — ship compiled JS to npm so `npm install -g agent-gauntlet` works with just Node.js (>=18), replacing Bun's Glob with picomatch and adding a Bun.build()-based build pipeline
+
 ## 0.10.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "A CLI tool for testing AI coding agents",
   "license": "Apache-2.0",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.11.0

This PR was generated by the `/release` command.

### Changes

- [#50](https://github.com/pacaplan/agent-gauntlet/pull/50) Remove Bun runtime requirement for end users — ship compiled JS to npm so `npm install -g agent-gauntlet` works with just Node.js (>=18)

When merged, the publish workflow will publish to npm and create a GitHub release.