### PR TITLE
fix: skip commit-merged auto-clean when uncommitted changes exist

### DIFF
--- a/openspec/specs/run-lifecycle/spec.md
+++ b/openspec/specs/run-lifecycle/spec.md
@@ -496,14 +496,24 @@ The execution state file MUST persist across all clean operations (manual and au
 - **THEN** `.execution_state` SHALL be deleted (reset)
 - **AND** the next run SHALL operate in first-run mode against base branch
 
-#### Scenario: Auto-clean resets execution state on commit merged
+#### Scenario: Auto-clean resets execution state on commit merged (clean tree)
 
 - **GIVEN** `.execution_state` exists with `commit: "abc123"`
 - **AND** commit "abc123" is now an ancestor of the base branch
+- **AND** `working_tree_ref` equals `commit` (no uncommitted changes were captured)
 - **WHEN** auto-clean detects the merged commit
-- **THEN** `.execution_state` SHALL be deleted (reset) unconditionally
-- **AND** the `working_tree_ref` validity SHALL NOT be checked (stash existence in git is irrelevant after merge)
+- **THEN** `.execution_state` SHALL be deleted (reset)
 - **AND** the next run SHALL operate in first-run mode against base branch
+
+#### Scenario: Commit merged but uncommitted changes present (dirty tree)
+
+- **GIVEN** `.execution_state` exists with `commit: "abc123"`
+- **AND** commit "abc123" is now an ancestor of the base branch
+- **AND** `working_tree_ref` differs from `commit` (uncommitted changes were captured)
+- **WHEN** auto-clean evaluates the context
+- **THEN** auto-clean SHALL NOT fire
+- **AND** `.execution_state` SHALL be preserved
+- **AND** logs SHALL remain in place for the retry counter to function correctly
 
 ### Requirement: Runtime Usage Limit Detection
 This requirement MUST record unhealthy adapters in the global unhealthy adapter state file rather than `.execution_state`.

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -49,14 +49,20 @@ export async function shouldAutoClean(
 		return { clean: false };
 	}
 
-	// Check if commit was merged into base branch
-	try {
-		const isMerged = await isCommitInBranch(state.commit, baseBranch);
-		if (isMerged) {
-			return { clean: true, reason: "commit merged", resetState: true };
+	// Check if commit was merged into base branch.
+	// Skip this check when working_tree_ref differs from commit, which indicates
+	// uncommitted changes were captured. In that case, the execution state still
+	// holds meaningful context (the working tree snapshot) and cleaning would
+	// destroy the retry counter and narrowed diff capability.
+	if (!state.working_tree_ref || state.working_tree_ref === state.commit) {
+		try {
+			const isMerged = await isCommitInBranch(state.commit, baseBranch);
+			if (isMerged) {
+				return { clean: true, reason: "commit merged", resetState: true };
+			}
+		} catch {
+			// If we can't check merge status, don't auto-clean
 		}
-	} catch {
-		// If we can't check merge status, don't auto-clean
 	}
 
 	return { clean: false };

--- a/test/commands/shared.test.ts
+++ b/test/commands/shared.test.ts
@@ -331,7 +331,7 @@ describe("shouldAutoClean", () => {
 	// with specific commit history, which is harder to set up in unit tests.
 	// Integration tests would be more appropriate for that scenario.
 
-	it("returns resetState: true when commit is merged (unconditional)", async () => {
+	it("returns resetState: true when commit is merged and tree is clean", async () => {
 		const mergedCommit = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 		const branchSpy = spyOn(executionState, "getCurrentBranch").mockResolvedValue("test-branch");
 		const mergedSpy = spyOn(executionState, "isCommitInBranch").mockResolvedValue(true);
@@ -340,7 +340,7 @@ describe("shouldAutoClean", () => {
 			last_run_completed_at: new Date().toISOString(),
 			branch: "test-branch",
 			commit: mergedCommit,
-			working_tree_ref: mergedCommit, // A valid ref — old code would set resetState: false
+			working_tree_ref: mergedCommit, // Same as commit = clean tree
 		};
 		await fs.writeFile(
 			path.join(TEST_DIR, getExecutionStateFilename()),
@@ -350,7 +350,56 @@ describe("shouldAutoClean", () => {
 		const result = await shouldAutoClean(TEST_DIR, "origin/main");
 		expect(result.clean).toBe(true);
 		expect(result.reason).toBe("commit merged");
-		expect(result.resetState).toBe(true); // MUST be true, regardless of working_tree_ref validity
+		expect(result.resetState).toBe(true);
+
+		branchSpy.mockRestore();
+		mergedSpy.mockRestore();
+	});
+
+	it("returns clean: false when commit is merged but uncommitted changes exist", async () => {
+		const mergedCommit = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+		const stashRef = "abcdef1234567890abcdef1234567890abcdef12";
+		const branchSpy = spyOn(executionState, "getCurrentBranch").mockResolvedValue("test-branch");
+		const mergedSpy = spyOn(executionState, "isCommitInBranch").mockResolvedValue(true);
+
+		const state = {
+			last_run_completed_at: new Date().toISOString(),
+			branch: "test-branch",
+			commit: mergedCommit,
+			working_tree_ref: stashRef, // Differs from commit = uncommitted changes
+		};
+		await fs.writeFile(
+			path.join(TEST_DIR, getExecutionStateFilename()),
+			JSON.stringify(state),
+		);
+
+		const result = await shouldAutoClean(TEST_DIR, "origin/main");
+		expect(result.clean).toBe(false);
+
+		branchSpy.mockRestore();
+		mergedSpy.mockRestore();
+	});
+
+	it("returns resetState: true when commit is merged and working_tree_ref is absent", async () => {
+		const mergedCommit = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+		const branchSpy = spyOn(executionState, "getCurrentBranch").mockResolvedValue("test-branch");
+		const mergedSpy = spyOn(executionState, "isCommitInBranch").mockResolvedValue(true);
+
+		const state = {
+			last_run_completed_at: new Date().toISOString(),
+			branch: "test-branch",
+			commit: mergedCommit,
+			// no working_tree_ref — legacy state file
+		};
+		await fs.writeFile(
+			path.join(TEST_DIR, getExecutionStateFilename()),
+			JSON.stringify(state),
+		);
+
+		const result = await shouldAutoClean(TEST_DIR, "origin/main");
+		expect(result.clean).toBe(true);
+		expect(result.reason).toBe("commit merged");
+		expect(result.resetState).toBe(true);
 
 		branchSpy.mockRestore();
 		mergedSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Fix false-positive "commit merged" auto-clean that fired when `working_tree_ref` differed from `commit` in `.execution_state`
- When a branch hasn't diverged from `origin/main` but has uncommitted changes, `isCommitInBranch` returns true and auto-clean wiped logs every run — preventing the retry counter from ever incrementing past 1
- Now `shouldAutoClean` skips the "commit merged" check when `working_tree_ref !== commit`, preserving logs and execution state for active uncommitted work

## Test plan
- [x] Existing test updated: commit merged + clean tree (`working_tree_ref === commit`) still triggers auto-clean
- [x] New test: commit merged + dirty tree (`working_tree_ref !== commit`) → `clean: false`
- [x] New test: legacy state file (no `working_tree_ref`) → falls through to merge check (backwards compat)
- [x] Full test suite: 553 tests pass, 0 failures
- [x] Gauntlet run passes on `main` with uncommitted changes (no false-positive auto-clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime usage limits now detected from actual adapter output and exceptions instead of preflight checks.

* **Bug Fixes**
  * Auto-clean now safely detects dirty working trees and preserves execution state when uncommitted changes exist.

* **Documentation**
  * Updated specification and test coverage to reflect improved error handling and working tree state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->