### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-gauntlet
 
+## 0.13.1
+
+### Patch Changes
+
+- [#58](https://github.com/pacaplan/agent-gauntlet/pull/58) Detect the default git branch dynamically instead of hard-coding `origin/main`, enabling correct behavior in repos that use `master` or other default branch names
+
 ## 0.13.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A CLI tool for testing AI coding agents",
   "license": "Apache-2.0",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.13.1

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.13.1

* **Bug Fixes**
  * Fixed default Git branch detection to support repositories using alternative branch names (e.g., master instead of main).

* **Chores**
  * Version bumped to 0.13.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->