### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # agent-gauntlet
 
+## 0.14.0
+
+### Minor Changes
+
+- [#60](https://github.com/pacaplan/agent-gauntlet/pull/60) Add gauntlet auto-invocation via skill frontmatter and start hooks, enabling automatic quality verification when coding tasks are detected
+
+- [#62](https://github.com/pacaplan/agent-gauntlet/pull/62) Redesign `init` command with interactive CLI selection, reviewer setup, and checksum-based change detection for idempotent re-runs
+
+### Patch Changes
+
+- [#61](https://github.com/pacaplan/agent-gauntlet/pull/61) Remove openspec `tasks.md` and simplify the proposal workflow to reduce overhead
+
 ## 0.13.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "A CLI tool for testing AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.14.0

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.