### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # agent-gauntlet
 
+## 0.15.0
+
+### Minor Changes
+
+- [#64](https://github.com/pacaplan/agent-gauntlet/pull/64) Refactor `gauntlet-run` to delegate log and JSON file processing to disposable haiku subagents, keeping the main agent's context window free of ephemeral detail
+
+- [#65](https://github.com/pacaplan/agent-gauntlet/pull/65) Add `agent-gauntlet status` CLI command, 3-tier subagent fallback strategy with Cursor `--trust` flag support, and prescriptive skill prompt improvements
+
+- [#66](https://github.com/pacaplan/agent-gauntlet/pull/66) Add `capture-eval-issues` skill that uses a sonnet subagent to judge review violations and capture noteworthy ones into `evals/inventory.yml` for the eval framework
+
+- [#67](https://github.com/pacaplan/agent-gauntlet/pull/67) Add per-adapter model resolution that automatically selects the highest-versioned CLI model matching a configured base name, with support for Cursor and Copilot adapters
+
+- [#68](https://github.com/pacaplan/agent-gauntlet/pull/68) Update built-in `code-quality` review prompt to conditionally dispatch pr-review-toolkit agents (`code-reviewer`, `silent-failure-hunter`, `type-design-analyzer`) with inline fallback when agents are unavailable
+
 ## 0.14.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A CLI tool for testing AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.15.0

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.15.0 with new status CLI, improved model resolution, enhanced workflow capabilities, and code quality improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->