### PR TITLE
fix: exclude CLAUDECODE env var to support Claude Code latest channel

### DIFF
--- a/src/cli-adapters/claude.ts
+++ b/src/cli-adapters/claude.ts
@@ -266,9 +266,8 @@ export class ClaudeAdapter implements CLIAdapter {
 	}): Promise<string> {
 		const fullContent = `${opts.prompt}\n\n--- DIFF ---\n${opts.diff}`;
 
-		const tmpDir = os.tmpdir();
 		const tmpFile = path.join(
-			tmpDir,
+			os.tmpdir(),
 			`gauntlet-claude-${process.pid}-${Date.now()}.txt`,
 		);
 		await fs.writeFile(tmpFile, fullContent);
@@ -294,8 +293,10 @@ export class ClaudeAdapter implements CLIAdapter {
 		}
 
 		const cleanup = () => fs.unlink(tmpFile).catch(() => {});
+		// Exclude CLAUDECODE so the child doesn't hit the nesting guard
+		const { CLAUDECODE: _, ...parentEnv } = process.env;
 		const execEnv = {
-			...process.env,
+			...parentEnv,
 			[GAUNTLET_STOP_HOOK_ACTIVE_ENV]: "1",
 			...otelEnv,
 			...thinkingEnv,


### PR DESCRIPTION
## Summary

- **Fix nesting guard**: Claude Code's latest channel (v2.1.47+) sets `CLAUDECODE=1` and refuses to start if it detects the variable, breaking the claude review adapter when running from within Claude Code. The fix excludes `CLAUDECODE` from the child process environment so reviews work normally.
- **Refactor skills to static distribution**: Rewrites skill installation to copy from a bundled `skills/` directory instead of generating from templates, simplifying maintenance and enabling direct editing.
- **Cleanup**: Removes dead checksum code, fixes test assertions for directory-path log format, and updates AGENTS.md guidelines.

## Commits

- `6b31036` fix: exclude CLAUDECODE env var from child process to avoid nesting guard
- `88c29b3` docs: update AGENTS.md skill sync guideline for static skills
- `e82389d` fix: update test assertions for directory-path log format
- `1da5eac` address PR review comments
- `e9679a7` refactor: remove dead checksum code and fix code-health metrics
- `189aae0` refactor: rewrite skill installation to copy from bundled skills/ directory
- `7e04921` refactor: create skills/ directory and remove skill-templates/
- `214fe1f` docs: add static skills distribution design

## Test plan

- [x] All gauntlet gates pass (build, lint, typecheck, test, security, code-health)
- [x] Both claude@1 and codex@2 reviews pass
- [x] Verified claude review adapter works from within Claude Code session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process isolation to prevent issues when CLI operations are nested or called recursively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->