### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # agent-gauntlet
 
+## 0.15.1
+
+### Patch Changes
+
+- [#70](https://github.com/pacaplan/agent-gauntlet/pull/70) Move skills from generated template strings to static distributable source files under `skills/`, simplifying maintenance and enabling direct file distribution
+
+- [#71](https://github.com/pacaplan/agent-gauntlet/pull/71) Exclude `CLAUDECODE` env var from child processes to prevent the nesting guard from blocking stop-hook execution in Claude Code's latest channel
+
 ## 0.15.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A CLI tool for testing AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.15.1

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Patch Release: 0.15.1**

* **Bug Fixes**
  * Fixed an integration issue with Claude Code that was preventing proper execution of stop-hooks in the latest channel.

* **Changes**
  * Skills distribution improved by transitioning to static source files for enhanced accessibility and direct file delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->