### PR TITLE
chore: release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-gauntlet
 
+## 0.15.2
+
+### Patch Changes
+
+- [#73](https://github.com/pacaplan/agent-gauntlet/pull/73) Add E2E integration tests for the `gauntlet-setup` skill and refactor the stop-hook E2E test to use `bun:test` format for consistency
+
 ## 0.15.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "A CLI tool for testing AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.15.2

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.