### PR TITLE
fix: replace OTel regex extraction with O(n) line-based scanner

### DIFF
--- a/src/cli-adapters/claude.ts
+++ b/src/cli-adapters/claude.ts
@@ -367,10 +367,11 @@ export class ClaudeAdapter implements CLIAdapter {
     thinkingBudget?: string;
   }): Promise<string> {
     const totalTimeout = (opts.timeoutMs ?? 300_000) + POST_PROCESS_BUFFER_MS;
+    let timer: ReturnType<typeof setTimeout>;
     return Promise.race([
-      this.doExecute(opts),
-      new Promise<never>((_, reject) =>
-        setTimeout(
+      this.doExecute(opts).finally(() => clearTimeout(timer)),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
           () =>
             reject(
               new Error(
@@ -378,8 +379,8 @@ export class ClaudeAdapter implements CLIAdapter {
               ),
             ),
           totalTimeout,
-        ),
-      ),
+        );
+      }),
     ]);
   }
 

--- a/test/cli-adapters/otel-scanner.test.ts
+++ b/test/cli-adapters/otel-scanner.test.ts
@@ -349,6 +349,13 @@ function buildAdversarialInput(lineCount: number): string {
     chunks.push(`line ${i}: descriptor: { dataPointType: stuff }`);
     chunks.push(`resource: { body: 'something' }`);
     chunks.push(`some { nested { content } with } braces`);
+    // Every 100th iteration, add a multi-line non-OTel block to exercise depth tracking
+    if (i % 100 === 0) {
+      chunks.push('{');
+      chunks.push('  "nonOtel": true,');
+      chunks.push('  "nested": { "value": 1 }');
+      chunks.push('}');
+    }
   }
   return chunks.join('\n');
 }


### PR DESCRIPTION
## Summary

- Replace `OTEL_METRIC_BLOCK_RE` and `OTEL_LOG_BLOCK_RE` regexes with an O(n) single-pass line scanner (`scanOtelBlocks`) that uses brace-depth tracking to extract OTel blocks without catastrophic backtracking
- Eliminate double-processing in the streaming path by removing `outputBuffer` and `stripOtelBlocks()`, using a single `extractOtelMetrics()` call on raw output
- Add defense-in-depth adapter timeout (`POST_PROCESS_BUFFER_MS = 30s`) wrapping the full `execute()` method via `Promise.race` with proper timer cleanup
- Add `safeExtractOtelMetrics` try/catch wrapper so extraction failures return raw output instead of crashing the review
- Add 30 tests covering `countBraceChange`, `classifyBlock`, `scanOtelBlocks`, end-to-end `extractOtelMetrics`, and performance regression (relative scaling assertion)

**Root cause:** The previous regexes used multiple `[\s\S]*?` patterns that created O(n²)–O(n³) backtracking on ~400KB subprocess output, hanging the gauntlet process at 99% CPU for 18+ minutes.

## Test plan

- [x] `bun test test/cli-adapters/otel-scanner.test.ts` — 30 new tests pass
- [x] `bun test` — all 719 tests pass
- [x] `bun run build` — builds cleanly
- [x] `bunx biome check src` — no lint errors
- [x] Gauntlet verification passed (3 iterations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)