### PR TITLE
chore: release v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # agent-gauntlet
 
+## 0.15.3
+
+### Patch Changes
+
+- [#75](https://github.com/pacaplan/agent-gauntlet/pull/75) Replace CodeScene integration with Biome's built-in clean code lint rules for complexity and style analysis
+
+- [#76](https://github.com/pacaplan/agent-gauntlet/pull/76) Replace OTel regex-based cost extraction with an O(n) line-based scanner for improved performance and reliability
+
 ## 0.15.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "A CLI tool for testing AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.15.3

This PR was generated by the `/release` command.

### Patch Changes

- [#75](https://github.com/pacaplan/agent-gauntlet/pull/75) Replace CodeScene integration with Biome's built-in clean code lint rules for complexity and style analysis
- [#76](https://github.com/pacaplan/agent-gauntlet/pull/76) Replace OTel regex-based cost extraction with an O(n) line-based scanner for improved performance and reliability

When merged, the publish workflow will publish to npm and create a GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized cost analysis and measurement operations for faster, more efficient results.

* **Bug Fixes**
  * Enhanced code analysis and linting with improved rule reliability and evaluation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->