### PR TITLE
chore: release v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # agent-gauntlet
 
+## 0.15.4
+
+### Patch Changes
+
+- [#78](https://github.com/pacaplan/agent-gauntlet/pull/78) Prevent verification mode from reporting false positives by fixing how pass/fail status is determined during verification runs
+
+- [#79](https://github.com/pacaplan/agent-gauntlet/pull/79) Prevent event-loop blocking in review output evaluation by avoiding synchronous processing of large review results
+
 ## 0.15.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "A CLI tool for testing AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v0.15.4

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.