### PR TITLE
fix: move ConsoleReporter output from stderr to stdout

### DIFF
--- a/src/output/console.ts
+++ b/src/output/console.ts
@@ -90,7 +90,7 @@ async function printIterationHistory(
       `Total: ${totalFixed} fixed, ${totalSkipped} skipped, ${totalFailed} failed${iterationsText}`,
     );
   } catch (err) {
-    console.warn(
+    console.log(
       chalk.yellow(`Warning: Failed to reconstruct history: ${err}`),
     );
   }

--- a/test/output/console.test.ts
+++ b/test/output/console.test.ts
@@ -28,18 +28,8 @@ describe("ConsoleReporter", () => {
 	});
 
 	describe("onJobStart", () => {
-		it("should log job start with [START] prefix", () => {
-			const reporter = new ConsoleReporter();
-			const job = { id: "check:test", type: "check" } as Job;
-
-			reporter.onJobStart(job);
-
-			expect(stdoutOutput.length).toBeGreaterThan(0);
-			expect(stdoutOutput.join("")).toContain("[START]");
-			expect(stdoutOutput.join("")).toContain("check:test");
-		});
-
-		it("should write job start to stdout so agents can see it", () => {
+		// Agents rely on stdout to see gate output via Bash tool
+		it("should write [START] prefix to stdout", () => {
 			const reporter = new ConsoleReporter();
 			const job = { id: "check:test", type: "check" } as Job;
 
@@ -48,6 +38,7 @@ describe("ConsoleReporter", () => {
 			const output = stdoutOutput.join("");
 			expect(output).toContain("[START]");
 			expect(output).toContain("check:test");
+			expect(logOutput).toEqual([]);
 		});
 	});
 
@@ -66,8 +57,10 @@ describe("ConsoleReporter", () => {
 			const output = stdoutOutput.join("");
 			expect(output).toContain("[PASS]");
 			expect(output).toContain("check:test");
+			expect(logOutput).toEqual([]);
 		});
 
+		// Agents rely on stdout to see failure details via Bash tool
 		it("should log [FAIL] for failing jobs with log path", () => {
 			const reporter = new ConsoleReporter();
 			const job = { id: "check:test", type: "check" } as Job;
@@ -86,6 +79,7 @@ describe("ConsoleReporter", () => {
 			expect(output).toContain("check:test");
 			expect(output).toContain("Tests failed");
 			expect(output).toContain("gauntlet_logs/check_test.log");
+			expect(logOutput).toEqual([]);
 		});
 
 		it("should log [ERROR] for errored jobs", () => {
@@ -106,30 +100,12 @@ describe("ConsoleReporter", () => {
 			expect(output).toContain("review:test");
 			expect(output).toContain("Failed to complete");
 			expect(output).toContain("gauntlet_logs/review_test.log");
-		});
-
-		it("should write job results to stdout so agents can see them", () => {
-			const reporter = new ConsoleReporter();
-			const job = { id: "check:test", type: "check" } as Job;
-			const result: GateResult = {
-				jobId: "check:test",
-				status: "fail",
-				duration: 1234,
-				message: "Tests failed",
-				logPath: "gauntlet_logs/check_test.log",
-			};
-
-			reporter.onJobComplete(job, result);
-
-			const output = stdoutOutput.join("");
-			expect(output).toContain("[FAIL]");
-			expect(output).toContain("check:test");
-			expect(output).toContain("Tests failed");
+			expect(logOutput).toEqual([]);
 		});
 	});
 
 	describe("printSummary", () => {
-		it("should log summary with status", async () => {
+		it("should write Passed summary to stdout", async () => {
 			const reporter = new ConsoleReporter();
 			const results: GateResult[] = [
 				{ jobId: "check:test", status: "pass", duration: 100 },
@@ -140,36 +116,7 @@ describe("ConsoleReporter", () => {
 			const output = stdoutOutput.join("");
 			expect(output).toContain("RESULTS SUMMARY");
 			expect(output).toContain("Status: Passed");
-		});
-
-		it("should show Failed status when jobs fail", async () => {
-			const reporter = new ConsoleReporter();
-			const results: GateResult[] = [
-				{
-					jobId: "check:test",
-					status: "fail",
-					duration: 100,
-					message: "Failed",
-				},
-			];
-
-			await reporter.printSummary(results);
-
-			const output = stdoutOutput.join("");
-			expect(output).toContain("Status: Failed");
-		});
-
-		it("should write full summary to stdout so agents can see it", async () => {
-			const reporter = new ConsoleReporter();
-			const results: GateResult[] = [
-				{ jobId: "check:test", status: "pass", duration: 100 },
-			];
-
-			await reporter.printSummary(results);
-
-			const output = stdoutOutput.join(" ");
-			expect(output).toContain("RESULTS SUMMARY");
-			expect(output).toContain("Status: Passed");
+			expect(logOutput).toEqual([]);
 		});
 
 		it("should write Failed summary to stdout", async () => {
@@ -185,9 +132,10 @@ describe("ConsoleReporter", () => {
 
 			await reporter.printSummary(results);
 
-			const output = stdoutOutput.join(" ");
+			const output = stdoutOutput.join("");
 			expect(output).toContain("RESULTS SUMMARY");
 			expect(output).toContain("Status: Failed");
+			expect(logOutput).toEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Agents running `agent-gauntlet run` via Bash couldn't see gate results — all ConsoleReporter output went to stderr, and Claude Code's Bash tool doesn't reliably display stderr on non-zero exit codes
- Changed all `console.error` → `console.log` in ConsoleReporter and helper functions (printSubResult, printSingleResult, printIterationHistory, printFixedAndSkipped, printSkippedItems)
- Console-sink (app-logger used by stop-hook) remains on stderr — only the ConsoleReporter moved to stdout
- Removed redundant duplicate `console.log` Status line added in v0.15.4

## Test plan

- [x] 6 ConsoleReporter tests pass (consolidated from 10, with stderr-empty assertions)
- [x] Full test suite passes (737/737)
- [x] Verified with `2>/dev/null` that output is visible on stdout only
- [ ] Run gauntlet in a real agent session to confirm output visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * All job status messages, warnings, iteration results, and summary information now emit to standard output (stdout) while preserving formatting and detail.

* **Tests**
  * Tests updated and expanded to assert that start, pass/fail/error markers, job results, and full summaries are written to stdout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->