### PR TITLE
fix: revert console output to stderr and fix process exit hang

### DIFF
--- a/.claude/skills/gauntlet-run/SKILL.md
+++ b/.claude/skills/gauntlet-run/SKILL.md
@@ -41,7 +41,7 @@ Execute the autonomous verification suite.
    - `Status: Passed with warnings` → Go to step 8.
    - `Status: Failed` → Continue to step 4. **You MUST continue — do not stop here.**
    - `Status: Retry limit exceeded` → Run `bun src/index.ts clean` to archive logs. Go to step 8.
-   - No status line visible → The command may have timed out or failed to run. Re-run with a longer timeout or investigate the error. Do NOT proceed as if it passed.
+   - No status line visible → **Known issue:** Bun can drop all stdout/stderr when LLM review subprocesses run. Read the console log file to get the status: find the latest `console.*.log` in the gauntlet log directory (e.g., `gauntlet_logs/console.1.log`) and look for the `Status:` line there. If no console log is found there, also check `gauntlet_logs/previous/` for logs from the most recent archived run. If no console log exists in either location, the command may have timed out or failed to run — re-run with a longer timeout or investigate the error. Do NOT proceed as if it passed.
 4. **Extract failures** (required when status is Failed):
    - Infer the log directory from the file paths in the console output (e.g., if output references `gauntlet_logs/check_._lint.1.log`, the log directory is `gauntlet_logs/`)
    - Read `extract-prompt.md` from this skill's directory

--- a/skills/gauntlet-run/SKILL.md
+++ b/skills/gauntlet-run/SKILL.md
@@ -41,7 +41,7 @@ Execute the autonomous verification suite.
    - `Status: Passed with warnings` → Go to step 8.
    - `Status: Failed` → Continue to step 4. **You MUST continue — do not stop here.**
    - `Status: Retry limit exceeded` → Run `agent-gauntlet clean` to archive logs. Go to step 8.
-   - No status line visible → The command may have timed out or failed to run. Re-run with a longer timeout or investigate the error. Do NOT proceed as if it passed.
+   - No status line visible → **Known issue:** Bun can drop all stdout/stderr when LLM review subprocesses run. Read the console log file to get the status: find the latest `console.*.log` in the gauntlet log directory (e.g., `gauntlet_logs/console.1.log`) and look for the `Status:` line there. If no console log is found there, also check `gauntlet_logs/previous/` for logs from the most recent archived run. If no console log exists in either location, the command may have timed out or failed to run — re-run with a longer timeout or investigate the error. Do NOT proceed as if it passed.
 4. **Extract failures** (required when status is Failed):
    - Infer the log directory from the file paths in the console output (e.g., if output references `gauntlet_logs/check_._lint.1.log`, the log directory is `gauntlet_logs/`)
    - Read `extract-prompt.md` from this skill's directory

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -24,6 +24,7 @@ export function registerRunCommand(program: Command): void {
         uncommitted: options.uncommitted,
       });
 
-      process.exitCode = isSuccessStatus(result.status) ? 0 : 1;
+      const code = isSuccessStatus(result.status) ? 0 : 1;
+      process.exit(code);
     });
 }

--- a/src/core/run-executor-helpers.ts
+++ b/src/core/run-executor-helpers.ts
@@ -286,9 +286,7 @@ export async function handleNoChanges(
       );
     }
 
-    const statusLabel = status === 'passed' ? 'Passed' : 'Passed with warnings';
     log.info(getStatusMessage(status));
-    console.log(`Status: ${statusLabel}`);
     return { status, message: getStatusMessage(status), gatesRun: 0 };
   }
 
@@ -301,12 +299,10 @@ export async function handleNoChanges(
     }
     const message = `No changes detected — ${totalViolations} violation(s) still outstanding.`;
     log.warn(message);
-    console.log(`Status: Failed`);
     return { status: 'failed', message, gatesRun: 0 };
   }
 
   log.info('No changes detected.');
-  console.log('Status: No changes');
   return {
     status: 'no_changes',
     message: getStatusMessage('no_changes'),

--- a/src/output/console.ts
+++ b/src/output/console.ts
@@ -29,7 +29,7 @@ function printSubResult(
 ): void {
   const { color, label } = statusStyle(sub.status);
   const logInfo = sub.status !== 'pass' ? logSuffix(sub.logPath) : '';
-  console.log(
+  console.error(
     color(
       `[${label}]  ${jobId} ${chalk.dim(sub.nameSuffix)} (${duration}) - ${sub.message}${logInfo}`,
     ),
@@ -54,9 +54,9 @@ function printSingleResult(
   }
 
   if (result.status === 'pass') {
-    console.log(color(`[${label}]  ${jobId} (${duration})`));
+    console.error(color(`[${label}]  ${jobId} (${duration})`));
   } else {
-    console.log(
+    console.error(
       color(`[${label}]  ${jobId} (${duration}) - ${message}${logInfo}`),
     );
   }
@@ -83,14 +83,16 @@ async function printIterationHistory(
     );
     const totalFailed = countTotalFailed(results);
 
-    console.log(`\n${chalk.bold(SEPARATOR)}`);
+    console.error(`\n${chalk.bold(SEPARATOR)}`);
     const iterationsText =
       history.length > 1 ? ` after ${history.length} iterations` : '';
-    console.log(
+    console.error(
       `Total: ${totalFixed} fixed, ${totalSkipped} skipped, ${totalFailed} failed${iterationsText}`,
     );
   } catch (err) {
-    console.log(chalk.yellow(`Warning: Failed to reconstruct history: ${err}`));
+    console.warn(
+      chalk.yellow(`Warning: Failed to reconstruct history: ${err}`),
+    );
   }
 }
 
@@ -106,9 +108,9 @@ function printFixedAndSkipped(
   for (const iter of history) {
     if (iter.fixed.length === 0 && iter.skipped.length === 0) continue;
 
-    console.log(`\nIteration ${iter.iteration}:`);
+    console.error(`\nIteration ${iter.iteration}:`);
     for (const f of iter.fixed) {
-      console.log(
+      console.error(
         chalk.green(
           `  ✓ Fixed: ${formatJobLabel(f.jobId, f.adapter)} - ${f.details}`,
         ),
@@ -123,13 +125,13 @@ function printSkippedItems(
   skipped: Awaited<ReturnType<typeof reconstructHistory>>[number]['skipped'],
 ): void {
   for (const s of skipped) {
-    console.log(
+    console.error(
       chalk.yellow(
         `  ⊘ Skipped: ${formatJobLabel(s.jobId, s.adapter)} - ${s.file}:${s.line} ${s.issue}`,
       ),
     );
     if (s.result) {
-      console.log(chalk.dim(`    Reason: ${s.result}`));
+      console.error(chalk.dim(`    Reason: ${s.result}`));
     }
   }
 }
@@ -337,7 +339,7 @@ function parseCheckErrorFallback(logContent: string): string[] {
 
 export class ConsoleReporter {
   onJobStart(job: Job) {
-    console.log(chalk.blue(`[START] ${job.id}`));
+    console.error(chalk.blue(`[START] ${job.id}`));
   }
 
   onJobComplete(job: Job, result: GateResult) {
@@ -357,9 +359,9 @@ export class ConsoleReporter {
     logDir?: string,
     statusOverride?: string,
   ) {
-    console.log(`\n${chalk.bold(SEPARATOR)}`);
-    console.log(chalk.bold('RESULTS SUMMARY'));
-    console.log(chalk.bold(SEPARATOR));
+    console.error(`\n${chalk.bold(SEPARATOR)}`);
+    console.error(chalk.bold('RESULTS SUMMARY'));
+    console.error(chalk.bold(SEPARATOR));
 
     if (logDir) {
       await printIterationHistory(logDir, results);
@@ -369,8 +371,8 @@ export class ConsoleReporter {
       results,
       statusOverride,
     );
-    console.log(statusColor(`Status: ${overallStatus}`));
-    console.log(chalk.bold(`${SEPARATOR}\n`));
+    console.error(statusColor(`Status: ${overallStatus}`));
+    console.error(chalk.bold(`${SEPARATOR}\n`));
   }
 
   /** @internal Public for testing */

--- a/test/core/run-executor-helpers.test.ts
+++ b/test/core/run-executor-helpers.test.ts
@@ -33,8 +33,6 @@ describe("handleNoChanges", () => {
 	let debugLogSpy: ReturnType<typeof spyOn>;
 	let hasSkippedSpy: ReturnType<typeof spyOn>;
 	let cleanLogsSpy: ReturnType<typeof spyOn>;
-	let originalConsoleLog: typeof console.log;
-	let stdoutOutput: string[];
 
 	beforeEach(() => {
 		loggerSpy = spyOn(appLogger, "getCategoryLogger").mockReturnValue(
@@ -50,11 +48,6 @@ describe("handleNoChanges", () => {
 		cleanLogsSpy = spyOn(shared, "cleanLogs").mockResolvedValue(
 			undefined as any,
 		);
-		originalConsoleLog = console.log;
-		stdoutOutput = [];
-		console.log = (...args: unknown[]) => {
-			stdoutOutput.push(args.map(String).join(" "));
-		};
 	});
 
 	afterEach(() => {
@@ -62,7 +55,6 @@ describe("handleNoChanges", () => {
 		debugLogSpy.mockRestore();
 		hasSkippedSpy.mockRestore();
 		cleanLogsSpy.mockRestore();
-		console.log = originalConsoleLog;
 	});
 
 	it("returns 'passed' when failuresMap is empty", async () => {
@@ -93,31 +85,5 @@ describe("handleNoChanges", () => {
 		expect(result.message).toContain("2");
 		expect(result.message).toContain("violation");
 		expect(result.gatesRun).toBe(0);
-	});
-
-	it("should write 'Status: Passed' to stdout when no changes and no failures", async () => {
-		const ctx = makeCtx();
-		const failuresMap = new Map();
-		await handleNoChanges(ctx, failuresMap);
-		const output = stdoutOutput.join(" ");
-		expect(output).toContain("Status: Passed");
-	});
-
-	it("should write 'Status: Failed' to stdout when violations outstanding", async () => {
-		const ctx = makeCtx();
-		const failuresMap = new Map();
-		const adapterMap = new Map();
-		adapterMap.set("lint", [{ file: "a.ts", line: 1, issue: "err" }]);
-		failuresMap.set("check:lint", adapterMap);
-		await handleNoChanges(ctx, failuresMap);
-		const output = stdoutOutput.join(" ");
-		expect(output).toContain("Status: Failed");
-	});
-
-	it("should write status to stdout when no failuresMap (first run, no changes)", async () => {
-		const ctx = makeCtx();
-		await handleNoChanges(ctx, undefined);
-		const output = stdoutOutput.join(" ");
-		expect(output).toContain("Status:");
 	});
 });

--- a/test/output/console.test.ts
+++ b/test/output/console.test.ts
@@ -5,40 +5,30 @@ import { ConsoleReporter } from "../../src/output/console";
 
 describe("ConsoleReporter", () => {
 	let originalConsoleError: typeof console.error;
-	let originalConsoleLog: typeof console.log;
-	let logOutput: string[];
-	let stdoutOutput: string[];
+	let errorOutput: string[];
 
 	beforeEach(() => {
 		originalConsoleError = console.error;
-		originalConsoleLog = console.log;
-		logOutput = [];
-		stdoutOutput = [];
+		errorOutput = [];
 		console.error = (...args: unknown[]) => {
-			logOutput.push(args.map(String).join(" "));
-		};
-		console.log = (...args: unknown[]) => {
-			stdoutOutput.push(args.map(String).join(" "));
+			errorOutput.push(args.map(String).join(" "));
 		};
 	});
 
 	afterEach(() => {
 		console.error = originalConsoleError;
-		console.log = originalConsoleLog;
 	});
 
 	describe("onJobStart", () => {
-		// Agents rely on stdout to see gate output via Bash tool
-		it("should write [START] prefix to stdout", () => {
+		it("should write [START] prefix to stderr", () => {
 			const reporter = new ConsoleReporter();
 			const job = { id: "check:test", type: "check" } as Job;
 
 			reporter.onJobStart(job);
 
-			const output = stdoutOutput.join("");
+			const output = errorOutput.join("");
 			expect(output).toContain("[START]");
 			expect(output).toContain("check:test");
-			expect(logOutput).toEqual([]);
 		});
 	});
 
@@ -54,13 +44,11 @@ describe("ConsoleReporter", () => {
 
 			reporter.onJobComplete(job, result);
 
-			const output = stdoutOutput.join("");
+			const output = errorOutput.join("");
 			expect(output).toContain("[PASS]");
 			expect(output).toContain("check:test");
-			expect(logOutput).toEqual([]);
 		});
 
-		// Agents rely on stdout to see failure details via Bash tool
 		it("should log [FAIL] for failing jobs with log path", () => {
 			const reporter = new ConsoleReporter();
 			const job = { id: "check:test", type: "check" } as Job;
@@ -74,12 +62,11 @@ describe("ConsoleReporter", () => {
 
 			reporter.onJobComplete(job, result);
 
-			const output = stdoutOutput.join("");
+			const output = errorOutput.join("");
 			expect(output).toContain("[FAIL]");
 			expect(output).toContain("check:test");
 			expect(output).toContain("Tests failed");
 			expect(output).toContain("gauntlet_logs/check_test.log");
-			expect(logOutput).toEqual([]);
 		});
 
 		it("should log [ERROR] for errored jobs", () => {
@@ -95,17 +82,16 @@ describe("ConsoleReporter", () => {
 
 			reporter.onJobComplete(job, result);
 
-			const output = stdoutOutput.join("");
+			const output = errorOutput.join("");
 			expect(output).toContain("[ERROR]");
 			expect(output).toContain("review:test");
 			expect(output).toContain("Failed to complete");
 			expect(output).toContain("gauntlet_logs/review_test.log");
-			expect(logOutput).toEqual([]);
 		});
 	});
 
 	describe("printSummary", () => {
-		it("should write Passed summary to stdout", async () => {
+		it("should write Passed summary to stderr", async () => {
 			const reporter = new ConsoleReporter();
 			const results: GateResult[] = [
 				{ jobId: "check:test", status: "pass", duration: 100 },
@@ -113,13 +99,12 @@ describe("ConsoleReporter", () => {
 
 			await reporter.printSummary(results);
 
-			const output = stdoutOutput.join("");
+			const output = errorOutput.join("");
 			expect(output).toContain("RESULTS SUMMARY");
 			expect(output).toContain("Status: Passed");
-			expect(logOutput).toEqual([]);
 		});
 
-		it("should write Failed summary to stdout", async () => {
+		it("should write Failed summary to stderr", async () => {
 			const reporter = new ConsoleReporter();
 			const results: GateResult[] = [
 				{
@@ -132,10 +117,9 @@ describe("ConsoleReporter", () => {
 
 			await reporter.printSummary(results);
 
-			const output = stdoutOutput.join("");
+			const output = errorOutput.join("");
 			expect(output).toContain("RESULTS SUMMARY");
 			expect(output).toContain("Status: Failed");
-			expect(logOutput).toEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Reverts misguided fixes from PRs #81 and #84 that attempted to address a Claude Code Bash tool output suppression bug but introduced their own issues:

- **console.ts**: Restore `console.error` for all reporter output (was changed to `console.log` in PR #81). stderr is the correct channel for CLI progress/status output.
- **run-executor-helpers.ts**: Remove duplicate `Status:` console.log lines added in PR #84 that duplicated what ConsoleReporter already outputs.
- **run.ts**: Revert `process.exitCode` back to `process.exit()` — `exitCode` causes the process to hang indefinitely because something keeps the event loop alive.
- **SKILL.md**: Add fallback instructions to read console log files when Bash tool output is suppressed by `claude -p` subprocesses.

The root cause is a Claude Code bug where spawning `claude -p` as a subprocess suppresses all Bash tool output. Filed as anthropics/claude-code#28407.

## Test plan

- [ ] All 737 tests pass
- [ ] `bun src/index.ts run` exits cleanly (no hang)
- [ ] Console output goes to stderr (verify with `bun src/index.ts run 2>/tmp/out.txt && cat /tmp/out.txt`)
- [ ] Gauntlet skill works with console log fallback when output is suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced troubleshooting guidance for missing status lines, clarifying a known issue and providing instructions to locate status information in log files.

* **Bug Fixes**
  * Improved process termination behavior to ensure proper exit codes.

* **Chores**
  * Adjusted console output streams to improve log organization and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->