### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # agent-gauntlet
 
+## 1.0.0
+
+### Major Changes
+
+- [#86](https://github.com/pacaplan/agent-gauntlet/pull/86) Remove the `gauntlet-fix-pr`, `gauntlet-push-pr`, and `wait-ci` commands, streamlining the CLI to focus on core verification functionality
+
+### Minor Changes
+
+- [#83](https://github.com/pacaplan/agent-gauntlet/pull/83) Add `agent-gauntlet skip` command for bypassing specific gates, and upgrade bundled openspec skills to the latest versions
+
+### Patch Changes
+
+- [#84](https://github.com/pacaplan/agent-gauntlet/pull/84) Ensure the stdout Status line is written on all exit paths and remove `2>&1` redirections that were mixing stderr into stdout
+
+- [#85](https://github.com/pacaplan/agent-gauntlet/pull/85) Revert ConsoleReporter output back to stderr and fix a process exit hang caused by pending stdout writes
+
 ## 0.15.5
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-gauntlet",
-  "version": "0.15.5",
+  "version": "1.0.0",
   "description": "A CLI tool for testing AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v1.0.0

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v1.0.0 release notes documenting removed legacy commands, newly available agent-gauntlet skip command, upgraded bundled openspec skills, and critical fixes to stdout/stderr handling and process hang behavior.

* **Chores**
  * Package version bumped to 1.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->