### PR TITLE
fix: detect reports validated file as changed after committing unstaged fix

### DIFF
--- a/src/core/change-detector.ts
+++ b/src/core/change-detector.ts
@@ -186,7 +186,21 @@ export class ChangeDetector {
   }
 
   private async getFixBaseChangedFiles(fixBase: string): Promise<string[]> {
-    return this.getDiffWithWorkingTree(fixBase);
+    // Use two-dot diff (direct content comparison) instead of three-dot diff.
+    // Three-dot diff resolves the merge-base first, which for stash refs
+    // (working_tree_ref) points to the pre-fix commit — producing false positives
+    // when the fix has been committed and the content matches the stash.
+    const { stdout: committed } = await execFileAsync('git', [
+      'diff',
+      '--name-only',
+      fixBase,
+      'HEAD',
+    ]);
+    const files = new Set([
+      ...this.parseOutput(committed),
+      ...(await this.getWorkingTreeFiles()),
+    ]);
+    return Array.from(files);
   }
 
   private async getUncommittedChangedFiles(): Promise<string[]> {

--- a/src/core/change-detector.ts
+++ b/src/core/change-detector.ts
@@ -6,7 +6,7 @@ const execFileAsync = promisify(execFile);
 
 /** Validate that a string is a safe git ref (hex SHA or branch-like name). */
 function isValidGitRef(ref: string): boolean {
-  return /^[a-zA-Z0-9._\-/]+$/.test(ref);
+  return /^[a-zA-Z0-9][a-zA-Z0-9._\-/]*$/.test(ref);
 }
 
 export interface ChangeDetectorOptions {

--- a/test/core/change-detector.test.ts
+++ b/test/core/change-detector.test.ts
@@ -60,6 +60,16 @@ describe("ChangeDetector fixBase support", () => {
 		uncommittedSpy.mockRestore();
 	});
 
+	it("rejects refs starting with a hyphen", async () => {
+		const detector = new ChangeDetector("origin/main", { fixBase: "--help" });
+		await expect(detector.getChangedFiles()).rejects.toThrow("Invalid fixBase ref");
+	});
+
+	it("rejects commit refs starting with a hyphen", async () => {
+		const detector = new ChangeDetector("origin/main", { commit: "-x" });
+		await expect(detector.getChangedFiles()).rejects.toThrow("Invalid commit ref");
+	});
+
 	it("priority order: commit > fixBase > uncommitted > default", () => {
 		const { readFileSync } = require("node:fs");
 		const { join } = require("node:path");

--- a/test/core/change-detector.test.ts
+++ b/test/core/change-detector.test.ts
@@ -7,7 +7,7 @@ describe("ChangeDetector fixBase support", () => {
 		const detector = new ChangeDetector("origin/main", { fixBase });
 		const spy = spyOn(
 			detector as any,
-			"getDiffWithWorkingTree",
+			"getFixBaseChangedFiles",
 		).mockResolvedValue(["src/foo.ts"]);
 
 		const files = await detector.getChangedFiles();
@@ -26,7 +26,7 @@ describe("ChangeDetector fixBase support", () => {
 		).mockResolvedValue(["src/bar.ts"]);
 		const fixBaseSpy = spyOn(
 			detector as any,
-			"getDiffWithWorkingTree",
+			"getFixBaseChangedFiles",
 		).mockResolvedValue(["src/foo.ts"]);
 
 		const files = await detector.getChangedFiles();
@@ -45,7 +45,7 @@ describe("ChangeDetector fixBase support", () => {
 		});
 		const fixBaseSpy = spyOn(
 			detector as any,
-			"getDiffWithWorkingTree",
+			"getFixBaseChangedFiles",
 		).mockResolvedValue(["src/foo.ts"]);
 		const uncommittedSpy = spyOn(
 			detector as any,

--- a/test/integration/working-tree-ref-e2e.test.ts
+++ b/test/integration/working-tree-ref-e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -89,10 +89,11 @@ beforeAll(async () => {
 	canRun = isDistBuilt();
 });
 
-afterAll(async () => {
+afterEach(async () => {
 	for (const dir of tempDirs) {
 		await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
 	}
+	tempDirs.length = 0;
 });
 
 describe("working-tree-ref E2E", () => {

--- a/test/integration/working-tree-ref-e2e.test.ts
+++ b/test/integration/working-tree-ref-e2e.test.ts
@@ -278,6 +278,14 @@ describe("working-tree-ref E2E", () => {
 				const tempDir = await createTestRepo();
 				tempDirs.push(tempDir);
 
+				// Strip CI env vars so detect uses config's base_branch ("base")
+				// instead of GITHUB_BASE_REF, which would trigger auto-clean
+				const cleanEnv = { ...process.env };
+				delete cleanEnv.CI;
+				delete cleanEnv.GITHUB_ACTIONS;
+				delete cleanEnv.GITHUB_BASE_REF;
+				delete cleanEnv.GITHUB_SHA;
+
 				// Step 1: Make an uncommitted change (simulates a review fix)
 				await fs.writeFile(
 					path.join(tempDir, "hello.ts"),
@@ -287,6 +295,7 @@ describe("working-tree-ref E2E", () => {
 				// Step 2: Run validator — saves working_tree_ref as stash snapshot
 				await spawnValidator(["run"], {
 					cwd: tempDir,
+					env: cleanEnv,
 					timeoutMs: TIMEOUT_MS,
 				});
 
@@ -306,6 +315,7 @@ describe("working-tree-ref E2E", () => {
 				// content matches the validated working_tree_ref
 				const detectResult = await spawnValidator(["detect"], {
 					cwd: tempDir,
+					env: cleanEnv,
 					timeoutMs: TIMEOUT_MS,
 				});
 

--- a/test/integration/working-tree-ref-e2e.test.ts
+++ b/test/integration/working-tree-ref-e2e.test.ts
@@ -269,4 +269,50 @@ describe("working-tree-ref E2E", () => {
 			},
 			{ timeout: TIMEOUT_MS * 2 },
 		);
+
+		it(
+			"Scenario: detect reports no changes after committing validated unstaged fix",
+			async () => {
+				if (!canRun) return;
+
+				const tempDir = await createTestRepo();
+				tempDirs.push(tempDir);
+
+				// Step 1: Make an uncommitted change (simulates a review fix)
+				await fs.writeFile(
+					path.join(tempDir, "hello.ts"),
+					"export const x = 0; // review fix\n",
+				);
+
+				// Step 2: Run validator — saves working_tree_ref as stash snapshot
+				await spawnValidator(["run"], {
+					cwd: tempDir,
+					timeoutMs: TIMEOUT_MS,
+				});
+
+				const state = await readExecutionState(tempDir);
+				expect(state).not.toBeNull();
+				const wtr = state?.working_tree_ref as string;
+				const commitRef = state?.commit as string;
+
+				// working_tree_ref should be a stash (differs from commit/HEAD)
+				expect(wtr).not.toBe(commitRef);
+
+				// Step 3: Commit the fix (same content as the stash snapshot)
+				await git(["add", "hello.ts"], tempDir);
+				await git(["commit", "-m", "apply review fix"], tempDir);
+
+				// Step 4: Run detect — should show NO changes since committed
+				// content matches the validated working_tree_ref
+				const detectResult = await spawnValidator(["detect"], {
+					cwd: tempDir,
+					timeoutMs: TIMEOUT_MS,
+				});
+
+				// detect exits 2 when no changes found, 0 when changes found
+				expect(detectResult.exitCode).toBe(2);
+				expect(detectResult.stdout).toContain("No changes detected");
+			},
+			{ timeout: TIMEOUT_MS * 2 },
+		);
 });


### PR DESCRIPTION
## Summary

Fixes #127 — `detect` falsely reported files as changed after the user committed a validated unstaged fix.

- **Root cause:** `getFixBaseChangedFiles` used a three-dot diff (`git diff fixBase...HEAD`), which resolves the merge-base. For stash refs (`working_tree_ref`), this points to the pre-fix commit, so the committed fix always appears as a new change.
- **Fix:** Switch to two-dot diff (`git diff fixBase HEAD`) for direct content comparison. When fixBase is an ancestor commit, two-dot and three-dot produce identical results, so existing behavior is preserved.
- **Security:** Replaced `execAsync` (shell interpolation) with `execFileAsync` (argv-based) to prevent command injection.
- **Test:** Added integration test that reproduces the exact bug scenario (run with unstaged fix → commit → detect). Strips CI env vars to prevent `GITHUB_BASE_REF` from triggering auto-clean in CI.

## Test plan

- [x] New integration test: "detect reports no changes after committing validated unstaged fix"
- [x] Verified test fails with old code (three-dot diff), passes with fix (two-dot diff)
- [x] Verified test passes with simulated CI env vars (`CI=true GITHUB_ACTIONS=true GITHUB_BASE_REF=main`)
- [x] All 594 existing tests pass
- [x] Verified two-dot and three-dot are equivalent for ancestor commits (non-stash fixBase)
- [x] Validator passed (checks + reviews)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Change detection now produces a more accurate set of changed files when comparing revisions with the workspace.

* **Bug Fixes**
  * Tightened validation for revision references; invalid refs now cause reject/error with a clear message.

* **Tests**
  * Updated unit tests to match the new detection flow and added cases for invalid refs.
  * Added an end-to-end test covering detection after committing previously uncommitted changes; test cleanup now runs after each case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->