### PR TITLE
chore: release v1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "agent-validator",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "source": "./",
       "description": "A configurable feedback loop runner for AI-assisted development workflows.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # agent-validator
 
+## 1.9.0
+
+### Minor Changes
+
+- [#129](https://github.com/Codagent-AI/agent-validator/pull/129) Add `--context-file` flag to pass structured context into validation runs, introduce a built-in `task-compliance` review that checks implementation against task requirements, and improve validator skill guidance
+
+### Patch Changes
+
+- [#128](https://github.com/Codagent-AI/agent-validator/pull/128) Fix change detector incorrectly reporting the validated file as changed after committing an unstaged fix
+
 ## 1.8.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",


### PR DESCRIPTION
## Release v1.9.0

This PR was generated by the `/release` command.

When merged, the publish workflow will publish to npm and create a GitHub release.