### PR TITLE
Eval: Cursor adapter in harness, Composer-2 configs, Apr 2026 report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ bin/
 
 # eval results
 evals/results/
+
+# local review output left in fixture codebases during eval development
+evals/fixtures/**/.review-output*.json

--- a/docs/eval-framework.md
+++ b/docs/eval-framework.md
@@ -16,12 +16,13 @@ The framework benchmarks adapters across configurations to find optimal settings
 
 ## Adapters
 
-The eval supports three adapters, plus alias support for running the same adapter with different models:
+The eval supports these adapters, plus alias support for running the same adapter with different models:
 
 | Adapter | CLI | Notes |
 |---------|-----|-------|
 | `claude` | `claude` | Claude Code CLI. Currently too slow for the 300s timeout in most configurations. |
 | `codex` | `codex` | Codex CLI (OpenAI). |
+| `cursor` | `agent` | Cursor CLI (`agent`). Model override uses `agent --list-models`. |
 | `github-copilot` | `copilot` | GitHub Copilot CLI. |
 
 Each adapter entry in the config can specify a `model` override and an `alias` that becomes its label in results:
@@ -63,7 +64,7 @@ evals/fixtures/
 
 Each fixture's codebase contains bugs specific to that reviewer only -- bugs belonging to other reviewers are fixed in that fixture's source files. This isolation ensures that each eval run measures detection of the exact issue class the reviewer is responsible for.
 
-The config specifies the fixture path (e.g., `fixture: fixtures/code-quality`), and the reviewer prompt file is auto-inferred from the directory name, mapping to the corresponding prompt at `src/built-in-reviews/<reviewer>.md`.
+The config specifies the fixture path (e.g., `fixture: fixtures/code-quality`), and the reviewer prompt file is auto-inferred from the directory name, mapping to the corresponding prompt at `src/built-in-reviews/<reviewer>.md`. For **combined** built-ins (`all-reviewers`, `security-and-errors`) there is no single `.md` file; set **`builtin_prompt`** in the eval YAML to that name so the harness loads the combined prompt via `loadBuiltInReview`.
 
 ### Issue counts
 
@@ -115,7 +116,8 @@ timeout_ms: 300000    # per-adapter timeout in milliseconds
 
 judge:
   adapter: claude         # which adapter scores the results
-  thinking_budget: "high" # thinking budget for the judge
+  thinking_budget: "high" # thinking budget for the judge (Claude Code CLI)
+  # model: optional; passed to the judge adapter when set
 ```
 
 ## Scoring Approach
@@ -139,7 +141,7 @@ After each adapter run, a judge LLM receives the adapter's violations alongside 
 
 From these, standard metrics are computed: precision (True Positives / reported) and recall (True Positives / expected).
 
-The judge uses a single consistent model across all runs (Claude with high thinking) to avoid introducing scoring variance.
+The judge uses a single consistent model across all runs (Claude Code with high thinking in the default eval config) to avoid introducing scoring variance.
 
 ## Token Caching Concern
 
@@ -150,20 +152,23 @@ Runs execute sequentially. Both Claude and OpenAI implement prompt caching with 
 ### Quick start
 
 ```bash
-# Full eval (all adapters, all configs)
-bun run evals/runner.ts
+# Full eval (all adapters in eval-config.yml)
+bun evals/run-eval.ts
+
+# Use an alternate matrix file (path relative to cwd or evals/)
+bun evals/run-eval.ts --eval-config=evals/eval-config.cursor-composer2-cq.yml
 
 # Dry run -- validate config and check adapter availability without making API calls
-bun run evals/runner.ts --dry-run
+bun evals/run-eval.ts --dry-run
 
 # Skip judge scoring -- run adapters only, no LLM judge pass
-bun run evals/runner.ts --skip-judge
+bun evals/run-eval.ts --skip-judge
 
 # Filter to a single adapter
-bun run evals/runner.ts --adapter=codex
+bun evals/run-eval.ts --adapter=codex
 
 # Filter to a specific configuration
-bun run evals/runner.ts --config=tools-off-low
+bun evals/run-eval.ts --config=tools-off-low
 ```
 
 ### Output
@@ -244,7 +249,7 @@ The tradeoff is no pre-built comparison UI -- but for the current configuration 
 | **False Positive (FP)** | -- | A violation reported by the adapter that does not match any ground truth issue. |
 | **False Negative (FN)** | -- | A ground truth issue that the adapter failed to detect (shown as "missed issues"). |
 | **Ground Truth** | -- | The set of known, seeded issues in the test fixture, each with an ID, file, line range, difficulty, and category. |
-| **Judge** | -- | An LLM (default: Claude with high thinking) that evaluates whether adapter violations match ground truth issues. Provides semantic matching rather than brittle keyword matching. |
+| **Judge** | -- | An LLM (default: Claude Code with high thinking) that evaluates whether adapter violations match ground truth issues. Provides semantic matching rather than brittle keyword matching. |
 | **Fixture** | -- | A per-reviewer test directory containing a codebase, diff.patch, and ground-truth.yml. Each fixture isolates bugs for a single reviewer type. |
 | **Telemetry** | -- | Token usage and cost data emitted by adapter CLIs during execution. Parsed from `[otel]`, `[codex-telemetry]`, or `[telemetry]` output lines. |
 | **Candidates Comparison** | -- | A JSON file (`evals/results/candidates-comparison.json`) that accumulates results across eval sessions for cross-run comparison. |

--- a/docs/eval-report-2026-04-25.md
+++ b/docs/eval-report-2026-04-25.md
@@ -32,20 +32,22 @@ Ground truth sizes: code-quality **24** issues, all-reviewers **56**, security-e
 | All-reviewers (combined prompt) | 56 | 3 | 0.56 | 0.31 | 0.40 | ~131.8s |
 | Security + EH combined | 32 | 3 | 0.70 | 0.65 | 0.67 | ~107.8s |
 
-**Artifacts (machine-readable):**
+**Result JSON (local, not in git):** each run writes under `evals/results/` (gitignored). This session’s timestamped files were:
 
-- [evals/results/eval-2026-04-24T15-19-09.json](../evals/results/eval-2026-04-24T15-19-09.json) — code-quality  
-- [evals/results/eval-2026-04-24T15-32-21.json](../evals/results/eval-2026-04-24T15-32-21.json) — all-reviewers  
-- [evals/results/eval-2026-04-24T15-43-52.json](../evals/results/eval-2026-04-24T15-43-52.json) — security-errors  
+- `eval-2026-04-24T15-19-09.json` — code-quality  
+- `eval-2026-04-24T15-32-21.json` — all-reviewers  
+- `eval-2026-04-24T15-43-52.json` — security-errors  
 
-Cursor CLI version recorded in each file: `2026.04.17-787b533`.
+Regenerate: from the repo root, run `bun evals/run-eval.ts` with each of the three `--eval-config=evals/eval-config.cursor-composer2-*.yml` files (no `--skip-judge` for full scoring). New files appear in `evals/results/`.
+
+Cursor CLI version recorded in each run: `2026.04.17-787b533`.
 
 ## Comparison to [eval-report-2026-04-05.md](eval-report-2026-04-05.md) (Copilot + Codex baselines)
 
-The April 2026-04-05 report benchmarked **copilot-sonnet**, **copilot-gpt5.3**, and **codex-gpt5.3**—not Cursor. Indicative **relative** placement for **cursor-composer-2** (this session):
+The April 2026-04-05 report benchmarked **copilot-sonnet**, **copilot-gpt5.3**, and **codex-gpt5.3**—not Cursor. Indicative **relative** placement for **cursor-composer2** (this session; alias in eval YAML):
 
-| Slice | April leaders (indicative) | cursor-composer-2 (this report) |
-|--------|----------------------------|---------------------------------|
+| Slice | April leaders (indicative) | cursor-composer2 (this report) |
+|--------|----------------------------|--------------------------------|
 | Code quality (24 issues) | copilot-sonnet **0.71 R / 0.87 P**; GPT configs **0.43–0.47 R** | **0.55 / 0.55** — below Sonnet; recall near GPT, precision lower than all three April rows |
 | All-reviewers (56) | **0.59–0.71 R**; **0.94–0.96 P** for top configs | **0.31 R / 0.56 P** — well below; one failed run in three |
 | Sec+EH only (32) | copilot-gpt5.3 combined **0.79 R / 0.77 P** (only config in that subsection) | **0.65 R / 0.70 P** — below that published row |

--- a/docs/eval-report-2026-04-25.md
+++ b/docs/eval-report-2026-04-25.md
@@ -1,0 +1,66 @@
+# Review Eval Report — Cursor + Composer 2 — 2026-04-25
+
+## Summary
+
+This report documents a **full three-phase eval** of the **Cursor CLI** (`agent`) with **`composer-2`**, **tools off**, **thinking low**, and the **Claude Code** adapter as the **LLM judge** (high thinking). No other review adapters (Copilot, Codex) were in the matrix—only **Cursor** for review, **Claude** for scoring.
+
+**Result JSON timestamps are 2026-04-24 (UTC).** This report is dated **2026-04-25** as the publication of those results.
+
+**Headline numbers (mean across runs in each phase):** code-quality about **0.55 precision / 0.55 recall**; **all-reviewers** about **0.56 precision / 0.31 recall**; **security + error-handling combined** about **0.70 precision / 0.65 recall**.
+
+Two adapter runs **failed** (status `error`, zero violations): **code-quality run 2/5** and **all-reviewers run 1/3**. Those runs are included in mean duration; scoring used **miss-all** semantics where the judge did not run on error rows (see [evals/runner.ts](../evals/runner.ts)). Re-running would tighten confidence intervals.
+
+## Candidate
+
+| Label | Review adapter | Model | Effort |
+|-------|----------------|-------|--------|
+| cursor-composer2 | `cursor` (`agent`) | `composer-2` | low |
+
+| Judge | Adapter | Thinking |
+|-------|---------|----------|
+| (default) | `claude` (Claude Code CLI) | high |
+
+Configs: [evals/eval-config.cursor-composer2-cq.yml](../evals/eval-config.cursor-composer2-cq.yml), [evals/eval-config.cursor-composer2-all-reviewers.yml](../evals/eval-config.cursor-composer2-all-reviewers.yml), [evals/eval-config.cursor-composer2-security-errors.yml](../evals/eval-config.cursor-composer2-security-errors.yml) (`builtin_prompt` for combined built-ins).
+
+## Results (aggregates)
+
+Ground truth sizes: code-quality **24** issues, all-reviewers **56**, security-errors **32**.
+
+| Phase | Ground truth | Runs | Mean precision | Mean recall | Mean F1 | Mean adapter time |
+|-------|----------------|------|----------------|-------------|---------|-------------------|
+| Code quality | 24 | 5 | 0.55 | 0.55 | 0.55 | ~115.7s |
+| All-reviewers (combined prompt) | 56 | 3 | 0.56 | 0.31 | 0.40 | ~131.8s |
+| Security + EH combined | 32 | 3 | 0.70 | 0.65 | 0.67 | ~107.8s |
+
+**Artifacts (machine-readable):**
+
+- [evals/results/eval-2026-04-24T15-19-09.json](../evals/results/eval-2026-04-24T15-19-09.json) — code-quality  
+- [evals/results/eval-2026-04-24T15-32-21.json](../evals/results/eval-2026-04-24T15-32-21.json) — all-reviewers  
+- [evals/results/eval-2026-04-24T15-43-52.json](../evals/results/eval-2026-04-24T15-43-52.json) — security-errors  
+
+Cursor CLI version recorded in each file: `2026.04.17-787b533`.
+
+## Comparison to [eval-report-2026-04-05.md](eval-report-2026-04-05.md) (Copilot + Codex baselines)
+
+The April 2026-04-05 report benchmarked **copilot-sonnet**, **copilot-gpt5.3**, and **codex-gpt5.3**—not Cursor. Indicative **relative** placement for **cursor-composer-2** (this session):
+
+| Slice | April leaders (indicative) | cursor-composer-2 (this report) |
+|--------|----------------------------|---------------------------------|
+| Code quality (24 issues) | copilot-sonnet **0.71 R / 0.87 P**; GPT configs **0.43–0.47 R** | **0.55 / 0.55** — below Sonnet; recall near GPT, precision lower than all three April rows |
+| All-reviewers (56) | **0.59–0.71 R**; **0.94–0.96 P** for top configs | **0.31 R / 0.56 P** — well below; one failed run in three |
+| Sec+EH only (32) | copilot-gpt5.3 combined **0.79 R / 0.77 P** (only config in that subsection) | **0.65 R / 0.70 P** — below that published row |
+
+**Interpretation:** On this harness, **Cursor + Composer 2** does **not** match **Copilot + Sonnet** from April; on **all-reviewers** the gap is large (recall in particular). The **sec+EH** combined slice is the **closest** to a prior benchmark, but still under the **copilot-gpt5.3** combined numbers from April. Different CLIs, models, and a single session—use as directional, not definitive.
+
+## Methodology
+
+- **Tool use** disabled (`allow_tool_use: false`).
+- **Timeouts:** 300s per run (code-quality), 600s (combined fixtures).
+- **Judge:** Claude Code, high thinking; optional `judge.model` omitted (harness default).
+- **Sequential** runs; no enforced pause between runs (optional 3–4 min pauses in April were for cache confounds—omitted here).
+
+## Next steps
+
+1. Investigate **adapter `error`** runs (retry, log capture from `agent` CLI).
+2. Re-run a **5×3×3** campaign after fixes to reduce variance; optionally add **Cursor** to a multi-adapter [evals/eval-config.yml](../evals/eval-config.yml) matrix to compare in one session.
+3. Keep [eval-report-2026-04-05.md](eval-report-2026-04-05.md) as the primary **multi-adapter** benchmark reference until a wider matrix includes Cursor.

--- a/evals/eval-config.cursor-composer2-all-reviewers.yml
+++ b/evals/eval-config.cursor-composer2-all-reviewers.yml
@@ -1,0 +1,16 @@
+# Cursor CLI (agent) + Composer — all-reviewers combined fixture, 3 runs.
+fixture: fixtures/all-reviewers
+builtin_prompt: all-reviewers
+
+adapters:
+  - name: cursor
+    model: composer-2
+    alias: cursor-composer2
+    allow_tool_use: false
+    thinking_budget: low
+
+runs_per_config: 3
+timeout_ms: 600000
+judge:
+  adapter: claude
+  thinking_budget: high

--- a/evals/eval-config.cursor-composer2-cq.yml
+++ b/evals/eval-config.cursor-composer2-cq.yml
@@ -1,0 +1,15 @@
+# Cursor CLI (agent) + Composer — code-quality fixture, 5 runs (April-style).
+fixture: fixtures/code-quality
+
+adapters:
+  - name: cursor
+    model: composer-2
+    alias: cursor-composer2
+    allow_tool_use: false
+    thinking_budget: low
+
+runs_per_config: 5
+timeout_ms: 300000
+judge:
+  adapter: claude
+  thinking_budget: high

--- a/evals/eval-config.cursor-composer2-security-errors.yml
+++ b/evals/eval-config.cursor-composer2-security-errors.yml
@@ -1,0 +1,16 @@
+# Cursor CLI (agent) + Composer — security + error-handling combined fixture, 3 runs.
+fixture: fixtures/security-errors
+builtin_prompt: security-and-errors
+
+adapters:
+  - name: cursor
+    model: composer-2
+    alias: cursor-composer2
+    allow_tool_use: false
+    thinking_budget: low
+
+runs_per_config: 3
+timeout_ms: 600000
+judge:
+  adapter: claude
+  thinking_budget: high

--- a/evals/judge.ts
+++ b/evals/judge.ts
@@ -13,6 +13,7 @@ export async function judgeRun(
 	groundTruth: GroundTruthIssue[],
 	judgeAdapterName: EvalAdapterName,
 	thinkingBudget: string,
+	options?: { model?: string },
 ): Promise<JudgeResult> {
 	const adapter = getAdapter(judgeAdapterName);
 	if (!adapter) {
@@ -25,6 +26,7 @@ export async function judgeRun(
 	const rawOutput = await adapter.execute({
 		prompt,
 		diff: "",
+		model: options?.model,
 		allowToolUse: false,
 		thinkingBudget,
 		timeoutMs: 300_000,

--- a/evals/run-eval.ts
+++ b/evals/run-eval.ts
@@ -9,6 +9,7 @@ function getArg(name: string): string | undefined {
 }
 
 const options = {
+	evalConfigPath: getArg("eval-config"),
 	adapterFilter: getArg("adapter"),
 	configFilter: getArg("config"),
 	dryRun: args.includes("--dry-run"),
@@ -20,6 +21,8 @@ console.log("=====================");
 
 if (options.dryRun) console.log("Mode: dry run (no adapter calls)");
 if (options.skipJudge) console.log("Mode: skip judge scoring");
+if (options.evalConfigPath)
+	console.log(`Eval config: ${options.evalConfigPath}`);
 if (options.adapterFilter)
 	console.log(`Filter: adapter=${options.adapterFilter}`);
 if (options.configFilter) console.log(`Filter: config=${options.configFilter}`);

--- a/evals/runner.ts
+++ b/evals/runner.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import YAML from "yaml";
 import { getAdapter } from "../src/cli-adapters/index.js";
+import { loadBuiltInReview } from "../src/built-in-reviews/index.js";
 // Re-export JSON_SYSTEM_INSTRUCTION from review gate
 import { JSON_SYSTEM_INSTRUCTION } from "../src/gates/review.js";
 import { runAdapter } from "./adapter-runner.js";
@@ -31,6 +32,8 @@ interface AdapterConfig {
 
 interface EvalConfig {
 	fixture: string;
+	/** When set, load prompt via `loadBuiltInReview` (combined built-ins: `all-reviewers`, `security-and-errors`, …). */
+	builtin_prompt?: string;
 	reviewer?: string;
 	adapters: (EvalAdapterName | AdapterConfig)[];
 	runs_per_config: number;
@@ -38,10 +41,14 @@ interface EvalConfig {
 	judge: {
 		adapter: EvalAdapterName;
 		thinking_budget: string;
+		/** Passed to the judge adapter (e.g. Copilot `--model`). */
+		model?: string;
 	};
 }
 
 export interface RunEvalOptions {
+	/** Path to eval YAML (absolute, or relative to cwd or evals/). Default: evals/eval-config.yml */
+	evalConfigPath?: string;
 	adapterFilter?: string;
 	configFilter?: string;
 	dryRun?: boolean;
@@ -52,6 +59,7 @@ export interface RunEvalOptions {
 const VERSION_COMMANDS: Record<EvalAdapterName, string> = {
 	claude: "claude --version",
 	codex: "codex --version",
+	cursor: "agent --version",
 	gemini: "gemini --version",
 	"github-copilot": "copilot --version",
 };
@@ -88,7 +96,23 @@ const MODEL_DETECTORS: Record<EvalAdapterName, () => string | undefined> = {
 		} catch { return undefined; }
 	},
 	"github-copilot": () => undefined,
+	cursor: () => undefined,
 };
+
+/** Resolve eval YAML path: absolute paths as-is; otherwise prefer cwd, then evals/. */
+function resolveEvalConfigPath(
+	evalsDir: string,
+	explicit: string | undefined,
+): string {
+	const defaultPath = resolve(evalsDir, "eval-config.yml");
+	if (!explicit) return defaultPath;
+	if (explicit.startsWith("/")) return explicit;
+	const fromCwd = resolve(process.cwd(), explicit);
+	if (existsSync(fromCwd)) return fromCwd;
+	const fromEvals = resolve(evalsDir, explicit);
+	if (existsSync(fromEvals)) return fromEvals;
+	return fromCwd;
+}
 
 function getAdapterVersionInfo(
 	adapter: EvalAdapterName,
@@ -111,7 +135,7 @@ export async function runEval(
 	const evalsDir = dirname(new URL(import.meta.url).pathname);
 
 	// Load eval config
-	const configPath = resolve(evalsDir, "eval-config.yml");
+	const configPath = resolveEvalConfigPath(evalsDir, options.evalConfigPath);
 	const configRaw = readFileSync(configPath, "utf-8");
 	const evalConfig: EvalConfig = YAML.parse(configRaw);
 
@@ -135,20 +159,28 @@ export async function runEval(
 		);
 	}
 
-	// Build review prompt — use reviewer config, or infer from fixture directory name
+	// Build review prompt — optional builtin_prompt for combined reviews; else .md by fixture/reviewer name
 	const fixtureBasename = evalConfig.fixture.split("/").pop() ?? "code-quality";
-	const promptFile = `${evalConfig.reviewer ?? fixtureBasename}.md`;
+	const reviewKey =
+		evalConfig.builtin_prompt ?? evalConfig.reviewer ?? fixtureBasename;
 	const promptPath = resolve(
 		evalsDir,
-		`../src/built-in-reviews/${promptFile}`,
+		`../src/built-in-reviews/${reviewKey}.md`,
 	);
-	if (!existsSync(promptPath)) {
-		throw new Error(
-			`Review prompt not found: ${promptPath}\n` +
-			`Set "reviewer" in eval-config.yml to an existing built-in review name.`,
-		);
+	let promptContent: string;
+	if (existsSync(promptPath)) {
+		promptContent = readFileSync(promptPath, "utf-8");
+	} else {
+		try {
+			promptContent = loadBuiltInReview(reviewKey);
+		} catch {
+			throw new Error(
+				`Review prompt not found: ${promptPath}\n` +
+					`Set "builtin_prompt" to a combined built-in (e.g. all-reviewers, security-and-errors), ` +
+					`or "reviewer" to an existing built-in name.`,
+			);
+		}
 	}
-	const promptContent = readFileSync(promptPath, "utf-8");
 	const fullPrompt = `${promptContent}\n${JSON_SYSTEM_INSTRUCTION}`;
 
 	// Generate eval matrix — one entry per adapter config (no cross-product)
@@ -295,6 +327,7 @@ export async function runEval(
 						groundTruth,
 						evalConfig.judge.adapter,
 						evalConfig.judge.thinking_budget,
+						{ model: evalConfig.judge.model },
 					);
 					judgeResultsByRun.set(result, judgeResult);
 					console.log(

--- a/evals/runner.ts
+++ b/evals/runner.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, resolve } from "node:path";
 import YAML from "yaml";
 import { getAdapter } from "../src/cli-adapters/index.js";
 import { loadBuiltInReview } from "../src/built-in-reviews/index.js";
@@ -106,7 +106,7 @@ function resolveEvalConfigPath(
 ): string {
 	const defaultPath = resolve(evalsDir, "eval-config.yml");
 	if (!explicit) return defaultPath;
-	if (explicit.startsWith("/")) return explicit;
+	if (isAbsolute(explicit)) return explicit;
 	const fromCwd = resolve(process.cwd(), explicit);
 	if (existsSync(fromCwd)) return fromCwd;
 	const fromEvals = resolve(evalsDir, explicit);
@@ -159,26 +159,42 @@ export async function runEval(
 		);
 	}
 
-	// Build review prompt — optional builtin_prompt for combined reviews; else .md by fixture/reviewer name
+	// Build review prompt — optional builtin_prompt loads combined built-ins only; else .md then fallback
 	const fixtureBasename = evalConfig.fixture.split("/").pop() ?? "code-quality";
 	const reviewKey =
 		evalConfig.builtin_prompt ?? evalConfig.reviewer ?? fixtureBasename;
-	const promptPath = resolve(
-		evalsDir,
-		`../src/built-in-reviews/${reviewKey}.md`,
-	);
 	let promptContent: string;
-	if (existsSync(promptPath)) {
-		promptContent = readFileSync(promptPath, "utf-8");
-	} else {
+	if (evalConfig.builtin_prompt) {
 		try {
 			promptContent = loadBuiltInReview(reviewKey);
-		} catch {
+		} catch (error) {
+			const underlying =
+				error instanceof Error ? error.message : String(error);
 			throw new Error(
-				`Review prompt not found: ${promptPath}\n` +
-					`Set "builtin_prompt" to a combined built-in (e.g. all-reviewers, security-and-errors), ` +
-					`or "reviewer" to an existing built-in name.`,
+				`Failed to load built-in review "${reviewKey}": ${underlying}\n` +
+					`Set "builtin_prompt" to a valid name (e.g. all-reviewers, security-and-errors).`,
 			);
+		}
+	} else {
+		const promptPath = resolve(
+			evalsDir,
+			`../src/built-in-reviews/${reviewKey}.md`,
+		);
+		if (existsSync(promptPath)) {
+			promptContent = readFileSync(promptPath, "utf-8");
+		} else {
+			try {
+				promptContent = loadBuiltInReview(reviewKey);
+			} catch (error) {
+				const underlying =
+					error instanceof Error ? error.message : String(error);
+				throw new Error(
+					`Review prompt not found: ${promptPath}\n` +
+						`Set "builtin_prompt" to a combined built-in (e.g. all-reviewers, security-and-errors), ` +
+						`or "reviewer" to an existing built-in name.\n` +
+						`Underlying error: ${underlying}`,
+				);
+			}
 		}
 	}
 	const fullPrompt = `${promptContent}\n${JSON_SYSTEM_INSTRUCTION}`;

--- a/evals/types.ts
+++ b/evals/types.ts
@@ -1,4 +1,9 @@
-export type EvalAdapterName = "claude" | "codex" | "gemini" | "github-copilot";
+export type EvalAdapterName =
+	| "claude"
+	| "codex"
+	| "cursor"
+	| "gemini"
+	| "github-copilot";
 
 export interface EvalConfiguration {
 	adapter: EvalAdapterName;

--- a/src/cli-adapters/model-resolution.ts
+++ b/src/cli-adapters/model-resolution.ts
@@ -41,7 +41,8 @@ export function resolveModelFromList(
   allModels: string[],
   opts: { baseName: string; preferThinking: boolean },
 ): string | undefined {
-  // Prefer an exact ID when the config matches a listed model (e.g. `composer-2`).
+  // Exact model IDs (e.g. `composer-2`) return as-is; preferThinking only applies
+  // when resolving a base segment like `opus` to `-thinking` variants, not for full IDs.
   if (allModels.includes(opts.baseName)) {
     return opts.baseName;
   }

--- a/src/cli-adapters/model-resolution.ts
+++ b/src/cli-adapters/model-resolution.ts
@@ -41,6 +41,11 @@ export function resolveModelFromList(
   allModels: string[],
   opts: { baseName: string; preferThinking: boolean },
 ): string | undefined {
+  // Prefer an exact ID when the config matches a listed model (e.g. `composer-2`).
+  if (allModels.includes(opts.baseName)) {
+    return opts.baseName;
+  }
+
   const candidates = allModels
     .filter((id) => id.split('-').includes(opts.baseName))
     .filter((id) => !TIER_SUFFIXES.some((s) => id.endsWith(s)));

--- a/test/cli-adapters/model-resolution.test.ts
+++ b/test/cli-adapters/model-resolution.test.ts
@@ -27,6 +27,16 @@ describe("resolveModelFromList", () => {
 		).toBe("gpt-5.3-codex");
 	});
 
+	it("uses exact model id when listed", () => {
+		const models = ["composer-1.5", "composer-2", "composer-2-fast"];
+		expect(
+			resolveModelFromList(models, {
+				baseName: "composer-2",
+				preferThinking: false,
+			}),
+		).toBe("composer-2");
+	});
+
 	it("excludes tier variants", () => {
 		const models = ["gpt-5.3-codex", "gpt-5.3-codex-low", "gpt-5.3-codex-high"];
 		expect(


### PR DESCRIPTION
## Summary

- Register `cursor` in the eval framework (types, `agent --version`, optional `judge.model`).
- `--eval-config=` for alternate eval YAML; `builtin_prompt` loads combined built-ins (`all-reviewers`, `security-and-errors`) via `loadBuiltInReview`.
- Model resolution: exact ID match when the config string appears in the CLI model list (e.g. `composer-2`).
- Add three Cursor + `composer-2` eval configs (CQ, all-reviewers, security-errors).
- Documentation: [docs/eval-report-2026-04-25.md](docs/eval-report-2026-04-25.md) (full judged session write-up); [docs/eval-framework.md](docs/eval-framework.md) updates; `.gitignore` for fixture `.review-output*.json`.

## Testing

- `bun test test/cli-adapters/model-resolution.test.ts`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cursor CLI adapter in evaluations
  * Introduced `--eval-config` CLI argument for specifying alternate evaluation configurations
  * Added three new evaluation configurations for Cursor CLI with Composer-2 model across different test suites

* **Documentation**
  * Updated evaluation framework documentation with Cursor adapter support and judge behavior clarifications
  * Added new evaluation report documenting Cursor CLI benchmark results

* **Chores**
  * Updated .gitignore to exclude evaluation fixture artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->