### PR TITLE
[codex] integrate agent-plugin installer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.2.1",
         "@logtape/logtape": "^2.0.2",
-        "agent-plugin": "https://github.com/Codagent-AI/agent-plugin/archive/3df4212892a9608e980616445382f80fd732f7ce.tar.gz",
+        "agent-plugin": "npm:@codagent-ai/agent-plugin@^0.1.1",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "gray-matter": "^4.0.3",
@@ -139,7 +139,7 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
 
-    "agent-plugin": ["agent-plugin@https://github.com/Codagent-AI/agent-plugin/archive/3df4212892a9608e980616445382f80fd732f7ce.tar.gz", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-CAP2ENIUO3U4EJScNeabbnWT/G70F4p7kJvWVEF/rcp2mGWokJDoU5LUX0Y4mQyJrCctNKYZsx8zjJw0wV3cEQ=="],
+    "agent-plugin": ["@codagent-ai/agent-plugin@0.1.1", "", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-fP8DCWOXYpvG9RlDrIUO9UXgtyDWzCFI1ScgjmErr9nqgMAgWOEwCZxDqU4OU3gK/GiyfmshkyYVG3Z4NW1Hig=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.2.1",
         "@logtape/logtape": "^2.0.2",
+        "agent-plugin": "https://github.com/Codagent-AI/agent-plugin/archive/3df4212892a9608e980616445382f80fd732f7ce.tar.gz",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "gray-matter": "^4.0.3",
@@ -137,6 +138,8 @@
     "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
 
     "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
+
+    "agent-plugin": ["agent-plugin@https://github.com/Codagent-AI/agent-plugin/archive/3df4212892a9608e980616445382f80fd732f7ce.tar.gz", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-CAP2ENIUO3U4EJScNeabbnWT/G70F4p7kJvWVEF/rcp2mGWokJDoU5LUX0Y4mQyJrCctNKYZsx8zjJw0wV3cEQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -340,6 +343,110 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "agent-plugin/@inquirer/prompts": ["@inquirer/prompts@8.4.3", "", { "dependencies": { "@inquirer/checkbox": "^5.1.5", "@inquirer/confirm": "^6.0.13", "@inquirer/editor": "^5.1.2", "@inquirer/expand": "^5.0.14", "@inquirer/input": "^5.0.13", "@inquirer/number": "^4.0.13", "@inquirer/password": "^5.0.13", "@inquirer/rawlist": "^5.2.9", "@inquirer/search": "^4.1.9", "@inquirer/select": "^5.1.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw=="],
+
     "@changesets/parse/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/checkbox": ["@inquirer/checkbox@5.1.5", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.10", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/confirm": ["@inquirer/confirm@6.0.13", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/editor": ["@inquirer/editor@5.1.2", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/external-editor": "^3.0.0", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/expand": ["@inquirer/expand@5.0.14", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/input": ["@inquirer/input@5.0.13", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/number": ["@inquirer/number@4.0.13", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/password": ["@inquirer/password@5.0.13", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/rawlist": ["@inquirer/rawlist@5.2.9", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/search": ["@inquirer/search@4.1.9", "", { "dependencies": { "@inquirer/core": "^11.1.10", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/select": ["@inquirer/select@5.1.5", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.10", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/checkbox/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/checkbox/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/checkbox/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/checkbox/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/confirm/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/confirm/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/editor/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/editor/@inquirer/external-editor": ["@inquirer/external-editor@3.0.0", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/editor/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/expand/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/expand/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/input/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/input/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/number/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/number/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/password/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/password/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/password/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/rawlist/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/rawlist/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/search/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/search/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/search/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/select/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/select/@inquirer/core": ["@inquirer/core@11.1.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/select/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/select/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/confirm/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/confirm/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/editor/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/editor/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/expand/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/expand/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/input/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/input/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/number/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/number/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/password/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/rawlist/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/rawlist/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "agent-plugin/@inquirer/prompts/@inquirer/search/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
   }
 }

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -125,7 +125,7 @@ Gate a commit behind optional Agent Validator validation.
 
 **Workflow:**
 1. Runs `agent-validator detect` — if no changes found, commits immediately (no validation)
-2. Parses inline intent from arguments: "run"/"full" → `/validator-run`; "check"/"checks" → `/validator-check`; "skip" → `agent-validator skip`; unclear → prompts user to choose
+2. Parses inline validator intent from arguments: "run"/"full" → `/validator-run`; "check"/"checks" → `/validator-check`; "skip" → `agent-validator skip`; unclear → prompts user to choose. Do not use for plain commit requests that do not mention validator, gauntlet, checks, validation, or skip.
 3. Runs the chosen validation skill; if it fails, asks "Ready to commit?" before proceeding
 4. Commits using an available commit skill if found, otherwise stages and commits directly
 
@@ -151,13 +151,14 @@ Skills are plain Markdown files with YAML frontmatter. You can edit them directl
 ```yaml
 ---
 name: validator-run
-description: Run the full verification Agent Validator
-disable-model-invocation: true
+description: Run the full Agent Validator only when explicitly requested
+disable-model-invocation: false
 allowed-tools: Bash
 ---
 ```
 
-- `disable-model-invocation: true` prevents Claude from automatically loading and invoking the skill. The user can still invoke it via `/name`. Use this for workflows with side effects (the default for Agent Validator skills).
+- `disable-model-invocation: true` prevents Claude from automatically loading and invoking the skill. The user can still invoke it via `/name`. Use this for workflows that should never be selected by model invocation.
+- `disable-model-invocation: false` allows model invocation. Keep the `description` and invocation policy narrow for side-effecting workflows so agents select them only when the user explicitly asks.
 - `user-invocable: false` hides the skill from the `/` autocomplete menu entirely.
 - `allowed-tools` restricts which tools the agent can use during execution
 

--- a/openspec/specs/agent-command/spec.md
+++ b/openspec/specs/agent-command/spec.md
@@ -180,8 +180,8 @@ The system SHALL store canonical skill files under `.validator/skills/validator-
 #### Scenario: Skill frontmatter format
 - **WHEN** a skill `SKILL.md` file is created
 - **THEN** it SHALL contain YAML frontmatter with `name`, `description`, and `allowed-tools` fields
-- **AND** non-auto-invoked validator skills (`validator-check`, `validator-status`) SHALL set `disable-model-invocation: true`
-- **AND** `validator-run` SHALL set `disable-model-invocation: false` for auto-invocation
+- **AND** non-model-invoked validator skills (`validator-status`) SHALL set `disable-model-invocation: true`
+- **AND** `validator-run` and `validator-check` SHALL set `disable-model-invocation: false` so explicit validation requests can invoke them through model skill selection
 
 #### Scenario: Hyphenated skill invocation
 - **GIVEN** a skill at `.claude/skills/validator-run/SKILL.md`
@@ -428,17 +428,17 @@ The `run` and `review` commands SHALL accept a repeatable `--enable-review <name
 - **WHEN** `agent-validate run --enable-review nonexistent` is invoked
 - **THEN** the run SHALL proceed normally without error
 
-### Requirement: Validator-Run Skill Auto-Invocation
-The validator-run skill SHALL have auto-invocation enabled so that Claude's skill invocation logic can trigger it automatically when the agent completes a coding task. The skill content is stored as static files under `skills/validator-run/` and installed to `.claude/skills/validator-run/` during init.
+### Requirement: Validator-Run Skill Model Invocation
+The validator-run skill SHALL allow model invocation for explicit user validation requests. The skill content is stored as static files under `skills/validator-run/` and installed to `.claude/skills/validator-run/` during init.
 
 The validator-run skill SHALL accept `--enable-review <name>` flags from the caller, appending them to the run command for each requested review.
 
-#### Scenario: Validator-run skill auto-invocation enabled
+#### Scenario: Validator-run skill model invocation enabled
 - **GIVEN** the validator-run skill is installed at `.claude/skills/validator-run/SKILL.md`
 - **WHEN** a user views the skill frontmatter
 - **THEN** the skill frontmatter SHALL set `disable-model-invocation: false`
-- **AND** the `description` field SHALL contain the phrase "final step after completing a coding task"
-- **AND** the `description` field SHALL contain the phrase "before committing, pushing, or creating PRs"
+- **AND** the `description` field SHALL state that the skill runs only when explicitly requested
+- **AND** the invocation policy SHALL tell agents not to choose the skill merely because a coding task was completed
 
 #### Scenario: Agent Validator-run skill passes caller-requested reviews
 - **GIVEN** the validator-run skill is installed and configured
@@ -449,4 +449,3 @@ The validator-run skill SHALL accept `--enable-review <name>` flags from the cal
 - **GIVEN** the validator-run skill is installed and configured
 - **WHEN** the validator-run skill is executed without any review requests from the caller
 - **THEN** the run command SHALL NOT include any `--enable-review` flags
-

--- a/openspec/specs/validator-commit/spec.md
+++ b/openspec/specs/validator-commit/spec.md
@@ -5,6 +5,18 @@ Specifies the `validator-commit` skill, which orchestrates change detection, val
 
 ## Requirements
 
+### Requirement: Explicit Validator Intent
+
+The `validator-commit` skill SHALL only be selected for commit requests that explicitly ask to involve Agent Validator, gauntlet validation, checks, validation, or skip behavior.
+
+#### Scenario: Plain commit request
+
+- **WHEN** the user asks only to commit changes without mentioning validator, gauntlet, checks, validation, or skip
+- **THEN** the agent SHALL NOT invoke `validator-commit`
+- **AND** the agent SHALL use its normal commit workflow instead
+
+---
+
 ### Requirement: Inline Validation Intent Parsing
 
 The `validator-commit` skill SHALL parse its ARGUMENTS string for a validation intent before prompting the user. If a clear intent is found, it SHALL use it directly without prompting.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:npm": "bun build.ts",
     "prepublishOnly": "bun run build:npm",
     "test": "bun test",
-    "test:e2e": "bun run build:npm && bun test test/integration/",
+    "test:e2e": "bun run build:npm && bun test test/integration/ && ./scripts/docker-init-e2e.sh",
     "lint": "biome check src",
     "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
     "changeset": "changeset",
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
-    "agent-plugin": "https://github.com/Codagent-AI/agent-plugin/archive/3df4212892a9608e980616445382f80fd732f7ce.tar.gz",
+    "agent-plugin": "npm:@codagent-ai/agent-plugin@^0.1.1",
     "@logtape/logtape": "^2.0.2",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
+    "agent-plugin": "https://github.com/Codagent-AI/agent-plugin/archive/3df4212892a9608e980616445382f80fd732f7ce.tar.gz",
     "@logtape/logtape": "^2.0.2",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",

--- a/scripts/docker-init-e2e.sh
+++ b/scripts/docker-init-e2e.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${IMAGE:-mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm}"
+WORKDIR="${WORKDIR:-/workspaces}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage: docker-init-e2e.sh
+
+Runs an opt-in Docker E2E test for `agent-validator init --yes` with real
+Claude Code, Codex, npm agent-plugin dependency, and Vercel skills installs.
+
+Environment:
+  IMAGE    Docker image to use.
+  WORKDIR  Container working directory.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+docker_args=(
+  --rm
+  -w "$WORKDIR"
+  -e "WORKDIR=$WORKDIR"
+  -e "USER=root"
+  -v "$VALIDATOR_ROOT:/agent-validator-source:ro"
+)
+
+if [[ -t 0 && -t 1 ]]; then
+  docker_args+=(-it)
+fi
+
+docker run "${docker_args[@]}" \
+  "$IMAGE" \
+  bash -lc '
+    set -euo pipefail
+
+    copy_source() {
+      local src="$1"
+      local dest="$2"
+      mkdir -p "$dest"
+      tar \
+        --exclude ./node_modules \
+        --exclude ./.git \
+        --exclude ./dist \
+        --exclude ./validator_logs \
+        -C "$src" \
+        -cf - . | tar -C "$dest" -xf -
+    }
+
+    require_file() {
+      local path="$1"
+      if [[ ! -f "$path" ]]; then
+        echo "Missing expected file: $path" >&2
+        exit 1
+      fi
+    }
+
+    require_dir() {
+      local path="$1"
+      if [[ ! -d "$path" ]]; then
+        echo "Missing expected directory: $path" >&2
+        exit 1
+      fi
+    }
+
+    require_output_contains() {
+      local command="$1"
+      local expected="$2"
+      local output
+      output="$(eval "$command")"
+      printf "%s\n" "$output"
+      if [[ "$output" != *"$expected"* ]]; then
+        echo "Expected output from \`$command\` to contain: $expected" >&2
+        exit 1
+      fi
+    }
+
+    echo "Installing runtime CLIs..."
+    npm install -g bun @openai/codex @anthropic-ai/claude-code
+    codex --version
+    claude --version
+
+    echo "Building and installing local agent-validator..."
+    copy_source /agent-validator-source /tmp/agent-validator-local
+    cd /tmp/agent-validator-local
+    bun install --frozen-lockfile
+    node -e "console.log(require.resolve(\"agent-plugin/package.json\"))"
+    bun run build:npm
+    npm install -g /tmp/agent-validator-local
+    agent-validator --version
+
+    echo "Running init in an empty project..."
+    mkdir -p "$WORKDIR/validator-init-e2e"
+    cd "$WORKDIR/validator-init-e2e"
+    agent-validator init --yes
+
+    echo "Verifying project scaffold..."
+    require_file .validator/config.yml
+    require_file .gitignore
+    grep -q "validator_logs" .gitignore
+    grep -q "default_preference:" .validator/config.yml
+    grep -q -- "- codex" .validator/config.yml
+    grep -q -- "- claude" .validator/config.yml
+
+    echo "Verifying Claude plugin install..."
+    require_output_contains "claude plugin list" "agent-validator"
+
+    echo "Verifying Codex skills install..."
+    require_dir /root/.agents/skills
+    require_file /root/.agents/skills/validator-setup/SKILL.md
+    require_file /root/.agents/skills/validator-run/SKILL.md
+    require_file /root/.agents/skills/validator-status/SKILL.md
+
+    echo
+    echo "Docker init E2E passed."
+  '

--- a/scripts/docker-published-smoke.sh
+++ b/scripts/docker-published-smoke.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${IMAGE:-mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm}"
+REPO="${REPO:-https://github.com/heroku/node-js-getting-started.git}"
+WORKDIR="${WORKDIR:-/workspaces}"
+INSTALL_FROM="npm"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage: docker-published-smoke.sh [--local]
+
+Runs a Docker smoke test against a sample Node.js repo, then leaves you in an
+interactive shell inside the container.
+
+Options:
+  --local   Install agent-validator from this checkout instead of npm.
+  -h, --help
+            Show this help.
+
+Environment:
+  IMAGE     Docker image to use.
+  REPO      Git repo to clone inside the container.
+  WORKDIR   Container working directory.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --local)
+      INSTALL_FROM="local"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+docker_args=(
+  --rm
+  -it
+  -w "$WORKDIR"
+  -e "REPO=$REPO"
+  -e "INSTALL_FROM=$INSTALL_FROM"
+  -e "WORKDIR=$WORKDIR"
+  -e "USER=root"
+)
+
+if [[ "$INSTALL_FROM" == "local" ]]; then
+  docker_args+=(-v "$VALIDATOR_ROOT:/agent-validator-source:ro")
+fi
+
+docker run "${docker_args[@]}" \
+  "$IMAGE" \
+  bash -lc '
+    set -euo pipefail
+
+    git clone "$REPO"
+    cd node-js-getting-started
+
+    npm ci
+
+    npm install -g bun @openai/codex @anthropic-ai/claude-code
+    if [[ "$INSTALL_FROM" == "local" ]]; then
+      mkdir -p /tmp/agent-validator-local
+      tar \
+        --exclude ./node_modules \
+        --exclude ./.git \
+        --exclude ./dist \
+        --exclude ./validator_logs \
+        -C /agent-validator-source \
+        -cf - . | tar -C /tmp/agent-validator-local -xf -
+      cd /tmp/agent-validator-local
+      bun install --frozen-lockfile
+      bun run build:npm
+      npm install -g /tmp/agent-validator-local
+      cd "$WORKDIR/node-js-getting-started"
+    else
+      npm install -g agent-validator
+    fi
+    npm install -g @codagent-ai/agent-plugin
+
+    agent-validator --version
+    agent-plugin --version
+    codex --version
+    claude --version
+
+    echo
+    echo "Setup complete. You are now in the sample repo inside the container."
+    exec bash -l
+  '

--- a/skills/validator-check/SKILL.md
+++ b/skills/validator-check/SKILL.md
@@ -1,14 +1,19 @@
 ---
 name: validator-check
 description: >-
-  Runs validator checks only without AI reviews for requests such as "run validator checks", "check without reviews", or "validate before commit without AI review".
-disable-model-invocation: true
+  Activates only for explicit checks-only validation requests such as "run validator checks", "checks only", "check without reviews", or validation without AI review. Runs checks without AI reviews.
+disable-model-invocation: false
 allowed-tools: Bash, Task
 ---
 
 # /validator-check
 Run validator checks only — no AI reviews.
 
+## Invocation Policy
+
+Use this skill only when the user explicitly asks for validator checks only, checks without reviews, static checks, or validation without AI review.
+
+Do not choose this skill for generic "run the validator", "run the gauntlet", "run validation", or final verification requests; use `/validator-run` for those.
 
 ## Procedure
 

--- a/skills/validator-commit/SKILL.md
+++ b/skills/validator-commit/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: validator-commit
 description: >-
-  Handles commit flows by detecting changes, optionally running validator validation, and completing commits for requests such as "commit with validator", "run checks before commit", "run validator then commit", or "skip validator and commit".
+  Activates only for explicit validator-aware commit requests such as "commit with validator", "run validator then commit", "run checks before commit", or "skip validator and commit". Excludes plain commit requests.
 disable-model-invocation: false
 allowed-tools: Bash, Task
 ---
 
 # /validator-commit $ARGUMENTS
 
-Commit with optional validator validation. Runs `agent-validate detect` first, validates based on intent (full run, checks only, or skip), handles failures, then commits.
+Commit with explicit validator validation intent. Runs `agent-validate detect` first, validates based on intent (full run, checks only, or skip), handles failures, then commits.
+
+## Invocation Policy
+
+Use this skill only when the user explicitly asks to involve Agent Validator in the commit flow, including full validation, checks-only validation, or intentionally skipping validator state as part of the commit.
+
+Do not choose this skill for a plain "commit", "make a commit", or "commit these changes" request that does not mention validator, gauntlet, checks, validation, or skip.
 
 ## Step 1 - Detect Changes
 

--- a/skills/validator-run/SKILL.md
+++ b/skills/validator-run/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: validator-run
 description: >-
-  Runs the full validator workflow after coding tasks for requests such as "run the validator", "run final verification", "validate before commit", or "run validation". Executes checks and reviews before commit, push, or PR creation.
+  Activates only for explicit full-validator requests such as "run the validator", "run the gauntlet", "run validation", or validation before commit, push, or PR creation. Includes checks and reviews, and excludes checks-only requests.
 disable-model-invocation: false
 allowed-tools: Bash, Task
 ---
 # /validator-run
 Execute the autonomous verification suite.
+
+## Invocation Policy
+
+Use this skill only for explicit validation requests, such as "run the validator", "run the gauntlet", "run validation", "validate this", or "validate before commit/push/PR".
+
+Do not choose this skill merely because a coding task was completed, because the user asked for a generic review, or because the user asked for checks only.
 
 ## Procedure
 

--- a/src/commands/init-prompts.ts
+++ b/src/commands/init-prompts.ts
@@ -44,15 +44,28 @@ export async function promptReviewCLIs(
 export async function promptInstallScope(
   skipPrompts: boolean,
 ): Promise<'user' | 'project'> {
-  if (skipPrompts) return 'project';
+  if (skipPrompts) return 'user';
 
   console.log();
   return select({
-    message: 'Install scope for Claude plugin and Codex skills:',
+    message: 'Install scope for agent plugins and skills:',
+    default: 'user' as const,
     choices: [
       { name: 'Local (project)', value: 'project' as const },
       { name: 'Global (user)', value: 'user' as const },
     ],
+  });
+}
+
+export async function promptAgentPluginInstallConfirmation(
+  skipPrompts: boolean,
+): Promise<boolean> {
+  if (skipPrompts) return true;
+
+  console.log();
+  return confirm({
+    message: 'Proceed with plugin installation?',
+    default: true,
   });
 }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,6 +8,7 @@ import { type CLIAdapter, getAllAdapters } from '../cli-adapters/index.js';
 import { installAgentPluginForAgents } from '../plugin/agent-plugin-cli.js';
 import { writeConfigYml } from './init-config-helpers.js';
 import {
+  promptAgentPluginInstallConfirmation,
   promptDevCLIs,
   promptInstallScope,
   promptNumReviews,
@@ -187,61 +188,31 @@ async function scaffoldValidatorDir(
   await writeConfigYml(targetDir, reviewCLINames, numReviews, reviewConfig);
 }
 
-/** Detect which adapters need plugin installation, logging already-installed adapters. */
-async function detectAdaptersNeedingInstall(
-  devAdapters: CLIAdapter[],
-  projectRoot: string,
-): Promise<CLIAdapter[]> {
-  const result: CLIAdapter[] = [];
-  for (const adapter of devAdapters) {
-    if (!adapter.installPlugin) continue;
-
-    if (adapter.detectPlugin) {
-      const existingScope = await adapter.detectPlugin(projectRoot);
-      if (existingScope) {
-        console.log(
-          chalk.dim(
-            `${adapter.name} plugin already installed at ${existingScope} scope, skipping install`,
-          ),
-        );
-        continue;
-      }
-    }
-
-    result.push(adapter);
-  }
-  return result;
-}
-
 async function installExternalFiles(
-  projectRoot: string,
+  _projectRoot: string,
   devAdapters: CLIAdapter[],
   skipPrompts: boolean,
 ): Promise<void> {
-  const devAdapterNames = new Set(devAdapters.map((adapter) => adapter.name));
-
-  const adaptersNeedingInstall = await detectAdaptersNeedingInstall(
-    devAdapters,
-    projectRoot,
-  );
-
-  // Prompt for scope only when at least one adapter needs installation
-  const needsScope =
-    adaptersNeedingInstall.length > 0 || devAdapterNames.has('codex');
-  const installScope: 'user' | 'project' = needsScope
-    ? await promptInstallScope(skipPrompts)
-    : 'project';
-
-  const targetNames = new Set(
-    devAdapters
-      .filter((adapter) => !adapter.installPlugin)
-      .map((adapter) => adapter.name),
-  );
-  for (const adapter of adaptersNeedingInstall) {
-    targetNames.add(adapter.name);
+  const targetNames = devAdapters.map((adapter) => adapter.name);
+  if (targetNames.length === 0) {
+    return;
   }
+
+  const installScope = await promptInstallScope(skipPrompts);
   installAgentPluginForAgents({
-    agents: [...targetNames],
+    agents: targetNames,
+    scope: installScope,
+    dryRun: true,
+  });
+
+  const confirmed = await promptAgentPluginInstallConfirmation(skipPrompts);
+  if (!confirmed) {
+    console.log(chalk.yellow('Plugin installation cancelled.'));
+    return;
+  }
+
+  installAgentPluginForAgents({
+    agents: targetNames,
     scope: installScope,
     yes: skipPrompts,
   });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,13 +5,10 @@ import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { type CLIAdapter, getAllAdapters } from '../cli-adapters/index.js';
-import { computeSkillChecksum } from './init-checksums.js';
+import { installAgentPluginForAgents } from '../plugin/agent-plugin-cli.js';
 import { writeConfigYml } from './init-config-helpers.js';
-import { getCodexSkillsBaseDir, installAdapterPlugin } from './init-plugin.js';
 import {
-  type OverwriteChoice,
   promptDevCLIs,
-  promptFileOverwrite,
   promptInstallScope,
   promptNumReviews,
   promptReviewCLIs,
@@ -63,7 +60,7 @@ interface InitOptions {
 }
 
 /** Native CLIs that support the /validator-setup skill invocation. */
-const NATIVE_CLIS = new Set(['claude', 'cursor', 'github-copilot']);
+const NATIVE_CLIS = new Set(['claude', 'github-copilot']);
 
 export function registerInitCommand(program: Command): void {
   program
@@ -190,68 +187,6 @@ async function scaffoldValidatorDir(
   await writeConfigYml(targetDir, reviewCLINames, numReviews, reviewConfig);
 }
 
-async function copyDirRecursive(opts: {
-  src: string;
-  dest: string;
-}): Promise<void> {
-  await fs.mkdir(opts.dest, { recursive: true });
-  const entries = await fs.readdir(opts.src, { withFileTypes: true });
-  for (const entry of entries) {
-    const srcPath = path.join(opts.src, entry.name);
-    const destPath = path.join(opts.dest, entry.name);
-    if (entry.isDirectory()) {
-      await copyDirRecursive({ src: srcPath, dest: destPath });
-    } else {
-      await fs.copyFile(srcPath, destPath);
-    }
-  }
-}
-
-interface UpdateAllState {
-  updateAll: boolean;
-}
-
-async function installSkillsWithChecksums(
-  projectRoot: string,
-  targetBaseDir: string,
-  skipPrompts: boolean,
-  updateAllState: UpdateAllState,
-): Promise<void> {
-  const skillsDir = path.isAbsolute(targetBaseDir)
-    ? targetBaseDir
-    : path.join(projectRoot, targetBaseDir);
-  for (const dirName of await getSkillDirNames()) {
-    const sourceDir = path.join(SKILLS_SOURCE_DIR, dirName);
-    const targetDir = path.join(skillsDir, dirName);
-    const relativeDir = `${path.relative(projectRoot, targetDir)}/`;
-
-    if (!(await exists(targetDir))) {
-      await copyDirRecursive({ src: sourceDir, dest: targetDir });
-      console.log(chalk.green(`Created ${relativeDir}`));
-      continue;
-    }
-
-    const sourceChecksum = await computeSkillChecksum(sourceDir);
-    const targetChecksum = await computeSkillChecksum(targetDir);
-    if (sourceChecksum === targetChecksum) continue;
-
-    let choice: OverwriteChoice;
-    if (skipPrompts || updateAllState.updateAll) {
-      choice = 'yes';
-    } else {
-      choice = await promptFileOverwrite(dirName, skipPrompts);
-      if (choice === 'all') {
-        updateAllState.updateAll = true;
-      }
-    }
-    if (choice === 'no') continue;
-
-    await fs.rm(targetDir, { recursive: true, force: true });
-    await copyDirRecursive({ src: sourceDir, dest: targetDir });
-    console.log(chalk.green(`Updated ${relativeDir}`));
-  }
-}
-
 /** Detect which adapters need plugin installation, logging already-installed adapters. */
 async function detectAdaptersNeedingInstall(
   devAdapters: CLIAdapter[],
@@ -278,40 +213,11 @@ async function detectAdaptersNeedingInstall(
   return result;
 }
 
-/** Install skills for non-Claude/Codex adapters (e.g. Gemini, Cursor). */
-async function installOtherAdapterSkills(
-  projectRoot: string,
-  devAdapters: CLIAdapter[],
-  skipPrompts: boolean,
-  updateAllState: UpdateAllState,
-): Promise<void> {
-  const seen = new Set<string>();
-  for (const adapter of devAdapters) {
-    if (
-      adapter.name === 'claude' ||
-      adapter.name === 'codex' ||
-      adapter.name === 'github-copilot'
-    )
-      continue;
-    const dir = adapter.getProjectSkillDir();
-    if (dir && !seen.has(dir)) {
-      seen.add(dir);
-      await installSkillsWithChecksums(
-        projectRoot,
-        dir,
-        skipPrompts,
-        updateAllState,
-      );
-    }
-  }
-}
-
 async function installExternalFiles(
   projectRoot: string,
   devAdapters: CLIAdapter[],
   skipPrompts: boolean,
 ): Promise<void> {
-  const updateAllState: UpdateAllState = { updateAll: false };
   const devAdapterNames = new Set(devAdapters.map((adapter) => adapter.name));
 
   const adaptersNeedingInstall = await detectAdaptersNeedingInstall(
@@ -326,26 +232,19 @@ async function installExternalFiles(
     ? await promptInstallScope(skipPrompts)
     : 'project';
 
-  for (const adapter of adaptersNeedingInstall) {
-    await installAdapterPlugin(adapter, projectRoot, installScope);
-  }
-
-  if (devAdapterNames.has('codex')) {
-    const codexBaseDir = getCodexSkillsBaseDir(installScope);
-    await installSkillsWithChecksums(
-      projectRoot,
-      codexBaseDir,
-      skipPrompts,
-      updateAllState,
-    );
-  }
-
-  await installOtherAdapterSkills(
-    projectRoot,
-    devAdapters,
-    skipPrompts,
-    updateAllState,
+  const targetNames = new Set(
+    devAdapters
+      .filter((adapter) => !adapter.installPlugin)
+      .map((adapter) => adapter.name),
   );
+  for (const adapter of adaptersNeedingInstall) {
+    targetNames.add(adapter.name);
+  }
+  installAgentPluginForAgents({
+    agents: [...targetNames],
+    scope: installScope,
+    yes: skipPrompts,
+  });
 }
 
 async function printPostInitInstructions(devCLINames: string[]): Promise<void> {
@@ -367,25 +266,25 @@ async function printPostInitInstructions(devCLINames: string[]): Promise<void> {
   if (hasCodex) {
     console.log(
       chalk.bold(
-        'To complete setup in Codex, reference the setup skill: .agents/skills/validator-setup/SKILL.md. This will guide you through configuring the static checks (unit tests, linters, etc.) that Agent Validator will run.',
+        'To complete setup in Codex, reference the setup skill: ~/.agents/skills/validator-setup/SKILL.md. This will guide you through configuring the static checks (unit tests, linters, etc.) that Agent Validator will run.',
       ),
     );
     console.log();
     console.log('Available Codex skills:');
     for (const dirName of await getSkillDirNames()) {
-      console.log(`  .agents/skills/${dirName}/SKILL.md`);
+      console.log(`  ~/.agents/skills/${dirName}/SKILL.md`);
     }
   }
   if (hasOtherNonNative) {
     console.log(
       chalk.bold(
-        'To complete setup, reference the setup skill in your CLI: @.claude/skills/validator-setup/SKILL.md. This will guide you through configuring the static checks (unit tests, linters, etc.) that Agent Validator will run.',
+        'To complete setup, reference the setup skill in your CLI: ~/.agents/skills/validator-setup/SKILL.md. This will guide you through configuring the static checks (unit tests, linters, etc.) that Agent Validator will run.',
       ),
     );
     console.log();
     console.log('Available skills:');
     for (const dirName of await getSkillDirNames()) {
-      console.log(`  @.claude/skills/${dirName}/SKILL.md`);
+      console.log(`  ~/.agents/skills/${dirName}/SKILL.md`);
     }
   }
 }

--- a/src/commands/plugin-update.ts
+++ b/src/commands/plugin-update.ts
@@ -1,10 +1,9 @@
-import { realpathSync, statSync } from 'node:fs';
-import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { CursorAdapter } from '../cli-adapters/cursor.js';
+import { updateAgentPluginForAgents } from '../plugin/agent-plugin-cli.js';
 import {
   addMarketplace,
   installPlugin,
@@ -12,25 +11,7 @@ import {
   updateMarketplace,
   updatePlugin,
 } from '../plugin/claude-cli.js';
-import { computeSkillChecksum } from './init-checksums.js';
 import { addToGitignore, exists } from './shared.js';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-// After bundling, __dirname is `dist/` (one level below package root).
-// In dev, __dirname is `src/commands/` (two levels below package root).
-const SKILLS_SOURCE_DIR = (() => {
-  const bundled = path.join(__dirname, '..', 'skills');
-  const dev = path.join(__dirname, '..', '..', 'skills');
-  try {
-    statSync(bundled);
-    return bundled;
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT' || code === 'ENOTDIR') return dev;
-    throw err;
-  }
-})();
 
 interface PluginEntry {
   name?: unknown;
@@ -41,31 +22,6 @@ interface PluginEntry {
 
 export interface PluginUpdateOptions {
   skipPrompts?: boolean;
-}
-
-async function getSkillDirNames(): Promise<string[]> {
-  const entries = await fs.readdir(SKILLS_SOURCE_DIR, { withFileTypes: true });
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .sort();
-}
-
-async function copyDirRecursive(opts: {
-  src: string;
-  dest: string;
-}): Promise<void> {
-  await fs.mkdir(opts.dest, { recursive: true });
-  const entries = await fs.readdir(opts.src, { withFileTypes: true });
-  for (const entry of entries) {
-    const srcPath = path.join(opts.src, entry.name);
-    const destPath = path.join(opts.dest, entry.name);
-    if (entry.isDirectory()) {
-      await copyDirRecursive({ src: srcPath, dest: destPath });
-    } else {
-      await fs.copyFile(srcPath, destPath);
-    }
-  }
 }
 
 function isInProjectScope(cwd: string, projectPath: string): boolean {
@@ -153,46 +109,7 @@ function printManualUpdateInstructions(installedName: string): void {
   );
 }
 
-async function warnAndRemoveOldGauntletSkills(
-  targetBase: string,
-): Promise<void> {
-  try {
-    const existing = await fs.readdir(targetBase, { withFileTypes: true });
-    const oldSkills = existing
-      .filter(
-        (entry) => entry.isDirectory() && entry.name.startsWith('gauntlet-'),
-      )
-      .map((entry) => entry.name);
-
-    if (oldSkills.length === 0) return;
-
-    console.log(
-      chalk.yellow(
-        `\nRenamed ${oldSkills.length} skill(s) from "gauntlet-*" to "validator-*":`,
-      ),
-    );
-    for (const name of oldSkills) {
-      const newName = name.replace(/^gauntlet-/, 'validator-');
-      console.log(chalk.yellow(`  ${name} → ${newName}`));
-    }
-    console.log(
-      chalk.yellow(
-        'If you reference these skills by name (e.g. in AGENTS.md), please update to the new names.\n',
-      ),
-    );
-
-    for (const name of oldSkills) {
-      await fs.rm(path.join(targetBase, name), {
-        recursive: true,
-        force: true,
-      });
-    }
-  } catch {
-    // Best effort — ignore errors reading the directory
-  }
-}
-
-async function refreshCodexSkills(cwd: string): Promise<void> {
+async function hasCodexSkills(cwd: string): Promise<boolean> {
   const localBase = path.join(cwd, '.agents', 'skills');
   // Check for new name first, then legacy name
   const localMarker = (await exists(path.join(localBase, 'validator-run')))
@@ -205,37 +122,7 @@ async function refreshCodexSkills(cwd: string): Promise<void> {
     ? path.join(globalBase, 'validator-run')
     : path.join(globalBase, 'gauntlet-run');
 
-  let targetBase: string | null = null;
-  if (await exists(localMarker)) {
-    targetBase = localBase;
-  } else if (await exists(globalMarker)) {
-    targetBase = globalBase;
-  }
-
-  if (!targetBase) {
-    return;
-  }
-
-  for (const dirName of await getSkillDirNames()) {
-    const sourceDir = path.join(SKILLS_SOURCE_DIR, dirName);
-    const targetDir = path.join(targetBase, dirName);
-    if (!(await exists(targetDir))) {
-      await copyDirRecursive({ src: sourceDir, dest: targetDir });
-      continue;
-    }
-
-    const sourceChecksum = await computeSkillChecksum(sourceDir);
-    const targetChecksum = await computeSkillChecksum(targetDir);
-    if (sourceChecksum === targetChecksum) {
-      continue;
-    }
-
-    await fs.rm(targetDir, { recursive: true, force: true });
-    await copyDirRecursive({ src: sourceDir, dest: targetDir });
-  }
-
-  // Warn about and remove old gauntlet-* skill directories
-  await warnAndRemoveOldGauntletSkills(targetBase);
+  return (await exists(localMarker)) || (await exists(globalMarker));
 }
 
 function isCliUnavailableError(err: unknown): boolean {
@@ -347,9 +234,10 @@ export async function runPluginUpdate(
   // Detect Cursor plugin installation
   const cursorAdapter = new CursorAdapter();
   const cursorScope = await cursorAdapter.detectPlugin(cwd);
+  const codexSkillsInstalled = await hasCodexSkills(cwd);
 
   // Error if nothing is installed at all
-  if (!(claudeDetected || cursorScope)) {
+  if (!(claudeDetected || cursorScope || codexSkillsInstalled)) {
     throw new Error(
       'No agent-validator plugin is installed for this project. Please run `agent-validate init` first.',
     );
@@ -363,7 +251,18 @@ export async function runPluginUpdate(
     await updateCursorPlugin(cursorAdapter, cursorScope, cwd);
   }
 
-  await refreshCodexSkills(cwd);
+  const agentPluginTargets = [
+    ...(claudeDetected ? ['claude'] : []),
+    ...(cursorScope ? ['cursor'] : []),
+    ...(codexSkillsInstalled ? ['codex'] : []),
+  ];
+  if (agentPluginTargets.length > 0) {
+    updateAgentPluginForAgents({
+      agents: agentPluginTargets,
+      scope: claudeDetected?.scope ?? cursorScope ?? 'user',
+      yes: true,
+    });
+  }
 
   // Ensure validator_logs is in .gitignore (backwards compat: log dir was renamed)
   await addToGitignore(cwd, 'validator_logs');

--- a/src/plugin/agent-plugin-cli.ts
+++ b/src/plugin/agent-plugin-cli.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const AGENT_PLUGIN_SOURCE = 'Codagent-AI/agent-validator';
+
+function resolveAgentPluginBin(): string {
+  const packageJson = require.resolve('agent-plugin/package.json');
+  return path.join(path.dirname(packageJson), 'dist', 'index.js');
+}
+
+export function toAgentPluginName(adapterName: string): string {
+  if (adapterName === 'github-copilot') return 'copilot';
+  return adapterName;
+}
+
+export function runAgentPlugin(args: string[]): void {
+  execFileSync(process.execPath, [resolveAgentPluginBin(), ...args], {
+    encoding: 'utf8',
+    stdio: 'inherit',
+    timeout: 120_000,
+  });
+}
+
+export function installAgentPluginForAgents(opts: {
+  agents: string[];
+  scope: 'user' | 'project';
+  yes?: boolean;
+}): void {
+  const args = ['add', AGENT_PLUGIN_SOURCE];
+  for (const agent of opts.agents) {
+    args.push('--agent', toAgentPluginName(agent));
+  }
+  if (opts.scope === 'project') args.push('--project');
+  if (opts.yes) args.push('--yes');
+  runAgentPlugin(args);
+}
+
+export function updateAgentPluginForAgents(opts: {
+  agents: string[];
+  scope?: 'user' | 'project';
+  yes?: boolean;
+}): void {
+  const args = ['update', 'agent-validator'];
+  for (const agent of opts.agents) {
+    args.push('--agent', toAgentPluginName(agent));
+  }
+  if (opts.scope === 'project') args.push('--project');
+  if (opts.yes) args.push('--yes');
+  runAgentPlugin(args);
+}

--- a/src/plugin/agent-plugin-cli.ts
+++ b/src/plugin/agent-plugin-cli.ts
@@ -6,6 +6,7 @@ const require = createRequire(import.meta.url);
 const AGENT_PLUGIN_SOURCE = 'Codagent-AI/agent-validator';
 
 function resolveAgentPluginBin(): string {
+  if (process.env.AGENT_PLUGIN_BIN) return process.env.AGENT_PLUGIN_BIN;
   const packageJson = require.resolve('agent-plugin/package.json');
   return path.join(path.dirname(packageJson), 'dist', 'index.js');
 }
@@ -27,6 +28,7 @@ export function installAgentPluginForAgents(opts: {
   agents: string[];
   scope: 'user' | 'project';
   yes?: boolean;
+  dryRun?: boolean;
 }): void {
   const args = ['add', AGENT_PLUGIN_SOURCE];
   for (const agent of opts.agents) {
@@ -34,6 +36,7 @@ export function installAgentPluginForAgents(opts: {
   }
   if (opts.scope === 'project') args.push('--project');
   if (opts.yes) args.push('--yes');
+  if (opts.dryRun) args.push('--dry-run');
   runAgentPlugin(args);
 }
 

--- a/src/scripts/newsletter-metrics.ts
+++ b/src/scripts/newsletter-metrics.ts
@@ -542,8 +542,6 @@ async function parseDebugLog(
       overrides,
       logModel,
     );
-    pendingTelemetryModels.delete(kv.cli);
-
     current.events.push({
       source: name,
       sourcePath: repoPath,

--- a/test/commands/init-copilot.test.ts
+++ b/test/commands/init-copilot.test.ts
@@ -18,6 +18,9 @@ let selectedNumReviews = 1;
 
 const mockCopilotInstallPlugin = mock(async () => ({ success: true }));
 const mockCopilotDetectPlugin = mock(async () => null as "user" | null);
+const installAgentPluginForAgentsMock = mock(
+	(_opts: { agents: string[]; scope: "project" | "user"; yes?: boolean }) => {},
+);
 
 const mockAdapters = [
 	{
@@ -71,6 +74,15 @@ mock.module("../../src/plugin/claude-cli.js", () => ({
 	listPlugins: async () => [],
 	updateMarketplace: async () => ({ success: true }),
 	updatePlugin: async () => ({ success: true }),
+}));
+
+mock.module("../../src/plugin/agent-plugin-cli.js", () => ({
+	installAgentPluginForAgents: (opts: {
+		agents: string[];
+		scope: "project" | "user";
+		yes?: boolean;
+	}) => installAgentPluginForAgentsMock(opts),
+	updateAgentPluginForAgents: () => {},
 }));
 
 const { registerInitCommand } = await import("../../src/commands/init.js");
@@ -130,7 +142,13 @@ describe("init command with github-copilot", () => {
 	it("installs plugin via installPlugin when not already installed", async () => {
 		await program.parseAsync(["node", "test", "init", "--yes"]);
 
-		expect(mockCopilotInstallPlugin).toHaveBeenCalledTimes(1);
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: ["github-copilot"],
+				scope: "project",
+				yes: true,
+			}),
+		);
 	});
 
 	it("skips install when plugin already detected", async () => {

--- a/test/commands/init-copilot.test.ts
+++ b/test/commands/init-copilot.test.ts
@@ -139,26 +139,33 @@ describe("init command with github-copilot", () => {
 		);
 	});
 
-	it("installs plugin via installPlugin when not already installed", async () => {
+	it("installs plugin via agent-plugin when not already installed", async () => {
 		await program.parseAsync(["node", "test", "init", "--yes"]);
 
 		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				agents: ["github-copilot"],
-				scope: "project",
+				scope: "user",
 				yes: true,
 			}),
 		);
 	});
 
-	it("skips install when plugin already detected", async () => {
+	it("passes github-copilot through to agent-plugin even when adapter detection would find an existing install", async () => {
 		mockCopilotDetectPlugin.mockImplementation(async () => "user" as const);
 
 		await program.parseAsync(["node", "test", "init", "--yes"]);
 
 		const output = logs.join("\n");
-		expect(output).toContain("already installed");
+		expect(output).not.toContain("already installed");
 		expect(mockCopilotInstallPlugin).not.toHaveBeenCalled();
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: ["github-copilot"],
+				scope: "user",
+				yes: true,
+			}),
+		);
 	});
 
 	it("does NOT copy skills to .github/skills via file copy", async () => {

--- a/test/commands/init-prompts.test.ts
+++ b/test/commands/init-prompts.test.ts
@@ -38,9 +38,9 @@ describe("promptInstallScope", () => {
 		selectValue = "project";
 	});
 
-	it("returns project scope when skipPrompts is true", async () => {
+	it("returns user scope when skipPrompts is true", async () => {
 		const result = await promptInstallScope(true);
-		expect(result).toBe("project");
+		expect(result).toBe("user");
 	});
 
 	it("returns selected scope when prompting", async () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -29,6 +29,9 @@ type PluginListEntry = {
 const listPluginsMock = mock(async () => [] as PluginListEntry[]);
 const updateMarketplaceMock = mock(async () => ({ success: true }));
 const updatePluginMock = mock(async () => ({ success: true }));
+const installAgentPluginForAgentsMock = mock(
+	(_opts: { agents: string[]; scope: "project" | "user"; yes?: boolean }) => {},
+);
 
 const mockAdapters = [
 	{
@@ -138,6 +141,15 @@ mock.module("../../src/plugin/claude-cli.js", () => ({
 	updatePlugin: () => updatePluginMock(),
 }));
 
+mock.module("../../src/plugin/agent-plugin-cli.js", () => ({
+	installAgentPluginForAgents: (opts: {
+		agents: string[];
+		scope: "project" | "user";
+		yes?: boolean;
+	}) => installAgentPluginForAgentsMock(opts),
+	updateAgentPluginForAgents: () => {},
+}));
+
 const { registerInitCommand } = await import("../../src/commands/init.js");
 
 describe("init command plugin installation", () => {
@@ -174,6 +186,7 @@ describe("init command plugin installation", () => {
 		listPluginsMock.mockImplementation(async () => []);
 		updateMarketplaceMock.mockClear();
 		updatePluginMock.mockClear();
+		installAgentPluginForAgentsMock.mockClear();
 	});
 
 	afterEach(async () => {
@@ -192,8 +205,13 @@ describe("init command plugin installation", () => {
 		listPluginsMock.mockImplementation(async () => []);
 		await program.parseAsync(["node", "test", "init", "--yes"]);
 
-		expect(addMarketplaceMock).toHaveBeenCalledTimes(1);
-		expect(installPluginMock).toHaveBeenCalledWith("project");
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: expect.arrayContaining(["claude", "codex", "cursor", "gemini"]),
+				scope: "project",
+				yes: true,
+			}),
+		);
 	});
 
 	it("uses selected user scope for Claude plugin install", async () => {
@@ -206,55 +224,13 @@ describe("init command plugin installation", () => {
 
 		await program.parseAsync(["node", "test", "init"]);
 
-		expect(installPluginMock).toHaveBeenCalledWith("user");
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: ["claude"],
+				scope: "user",
+			}),
+		);
 		await fs.rm(fakeHome, { recursive: true, force: true });
-	});
-
-	it("warns and continues if marketplace add fails", async () => {
-		addMarketplaceMock.mockImplementationOnce(async () => ({
-			success: false,
-			stderr: "marketplace unavailable",
-		}));
-
-		await program.parseAsync(["node", "test", "init", "--yes"]);
-
-		const output = logs.join("\n");
-		expect(output).toContain("plugin installation failed");
-		expect(output).toContain(
-			"claude plugin marketplace add Codagent-AI/agent-validator",
-		);
-		expect(output).toContain("claude plugin install agent-validator --scope project");
-
-		const codexSkill = path.join(
-			testDir,
-			".agents",
-			"skills",
-			"validator-run",
-			"SKILL.md",
-		);
-		expect((await fs.stat(codexSkill).catch(() => null))?.isFile()).toBe(true);
-	});
-
-	it("warns and continues if plugin install fails", async () => {
-		installPluginMock.mockImplementationOnce(async () => ({
-			success: false,
-			stderr: "install error",
-		}));
-
-		await program.parseAsync(["node", "test", "init", "--yes"]);
-
-		const output = logs.join("\n");
-		expect(output).toContain("plugin installation failed");
-		expect(output).toContain("claude plugin install agent-validator --scope project");
-
-		const codexSkill = path.join(
-			testDir,
-			".agents",
-			"skills",
-			"validator-check",
-			"SKILL.md",
-		);
-		expect((await fs.stat(codexSkill).catch(() => null))?.isFile()).toBe(true);
 	});
 
 	it("does not write Claude hooks to settings.local.json", async () => {
@@ -264,48 +240,46 @@ describe("init command plugin installation", () => {
 		expect(await fs.stat(settingsPath).catch(() => null)).toBeNull();
 	});
 
-	it("installs Codex skills locally when project scope is selected", async () => {
+	it("delegates Codex fallback to agent-plugin even when project scope is selected", async () => {
 		selectedInstallScope = "project";
 		await program.parseAsync(["node", "test", "init"]);
 
-		const codexSkill = path.join(
-			testDir,
-			".agents",
-			"skills",
-			"validator-status",
-			"SKILL.md",
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: expect.arrayContaining(["codex"]),
+				scope: "project",
+			}),
 		);
-		expect((await fs.stat(codexSkill).catch(() => null))?.isFile()).toBe(true);
 	});
 
-	it("installs Codex skills globally when user scope is selected", async () => {
+	it("delegates Codex fallback to agent-plugin when user scope is selected", async () => {
 		selectedInstallScope = "user";
 		const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "validator-home-"));
 		process.env.HOME = fakeHome;
 
 		await program.parseAsync(["node", "test", "init"]);
 
-		const globalSkill = path.join(
-			fakeHome,
-			".agents",
-			"skills",
-			"validator-help",
-			"SKILL.md",
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: expect.arrayContaining(["codex"]),
+				scope: "user",
+			}),
 		);
-		expect((await fs.stat(globalSkill).catch(() => null))?.isFile()).toBe(true);
 		await fs.rm(fakeHome, { recursive: true, force: true });
 	});
 
-	it("keeps non-Claude behavior for Gemini/Cursor by copying .claude skills", async () => {
+	it("delegates Gemini/Cursor fallback to agent-plugin instead of copying skills", async () => {
 		selectedDevCliNames = ["gemini", "cursor"];
 
 		await program.parseAsync(["node", "test", "init"]);
 
 		expect(addMarketplaceMock).not.toHaveBeenCalled();
 		expect(installPluginMock).not.toHaveBeenCalled();
-
-		const skill = path.join(testDir, ".claude", "skills", "validator-setup", "SKILL.md");
-		expect((await fs.stat(skill).catch(() => null))?.isFile()).toBe(true);
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: expect.arrayContaining(["gemini", "cursor"]),
+			}),
+		);
 	});
 
 	it("skips scope prompt and install when plugin already installed at user scope", async () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -30,8 +30,14 @@ const listPluginsMock = mock(async () => [] as PluginListEntry[]);
 const updateMarketplaceMock = mock(async () => ({ success: true }));
 const updatePluginMock = mock(async () => ({ success: true }));
 const installAgentPluginForAgentsMock = mock(
-	(_opts: { agents: string[]; scope: "project" | "user"; yes?: boolean }) => {},
+	(_opts: {
+		agents: string[];
+		scope: "project" | "user";
+		yes?: boolean;
+		dryRun?: boolean;
+	}) => {},
 );
+let confirmAgentPluginInstall = true;
 
 const mockAdapters = [
 	{
@@ -130,7 +136,12 @@ mock.module("@inquirer/prompts", () => ({
 		if (opts.message?.includes("Install scope")) return selectedInstallScope;
 		return "yes";
 	},
-	confirm: async () => true,
+	confirm: async (opts: { message?: string }) => {
+		if (opts.message?.includes("Proceed with plugin installation")) {
+			return confirmAgentPluginInstall;
+		}
+		return true;
+	},
 }));
 
 mock.module("../../src/plugin/claude-cli.js", () => ({
@@ -146,6 +157,7 @@ mock.module("../../src/plugin/agent-plugin-cli.js", () => ({
 		agents: string[];
 		scope: "project" | "user";
 		yes?: boolean;
+		dryRun?: boolean;
 	}) => installAgentPluginForAgentsMock(opts),
 	updateAgentPluginForAgents: () => {},
 }));
@@ -178,8 +190,9 @@ describe("init command plugin installation", () => {
 		selectedDevCliNames = ["claude", "codex", "gemini", "cursor"];
 		selectedReviewCliNames = ["claude", "codex", "gemini", "cursor"];
 		selectedBuiltInReviews = ["code-quality", "security", "error-handling"];
-		selectedInstallScope = "project";
+		selectedInstallScope = "user";
 		selectedNumReviews = 1;
+		confirmAgentPluginInstall = true;
 		addMarketplaceMock.mockClear();
 		installPluginMock.mockClear();
 		listPluginsMock.mockClear();
@@ -201,14 +214,23 @@ describe("init command plugin installation", () => {
 		await fs.rm(testDir, { recursive: true, force: true });
 	});
 
-	it("uses project scope with --yes and installs Claude plugin when not already installed", async () => {
+	it("uses user scope with --yes and installs Claude plugin when not already installed", async () => {
 		listPluginsMock.mockImplementation(async () => []);
 		await program.parseAsync(["node", "test", "init", "--yes"]);
 
-		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+		expect(installAgentPluginForAgentsMock).toHaveBeenNthCalledWith(
+			1,
 			expect.objectContaining({
 				agents: expect.arrayContaining(["claude", "codex", "cursor", "gemini"]),
-				scope: "project",
+				scope: "user",
+				dryRun: true,
+			}),
+		);
+		expect(installAgentPluginForAgentsMock).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				agents: expect.arrayContaining(["claude", "codex", "cursor", "gemini"]),
+				scope: "user",
 				yes: true,
 			}),
 		);
@@ -224,7 +246,7 @@ describe("init command plugin installation", () => {
 
 		await program.parseAsync(["node", "test", "init"]);
 
-		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+		expect(installAgentPluginForAgentsMock).toHaveBeenLastCalledWith(
 			expect.objectContaining({
 				agents: ["claude"],
 				scope: "user",
@@ -244,7 +266,7 @@ describe("init command plugin installation", () => {
 		selectedInstallScope = "project";
 		await program.parseAsync(["node", "test", "init"]);
 
-		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+		expect(installAgentPluginForAgentsMock).toHaveBeenLastCalledWith(
 			expect.objectContaining({
 				agents: expect.arrayContaining(["codex"]),
 				scope: "project",
@@ -259,7 +281,7 @@ describe("init command plugin installation", () => {
 
 		await program.parseAsync(["node", "test", "init"]);
 
-		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+		expect(installAgentPluginForAgentsMock).toHaveBeenLastCalledWith(
 			expect.objectContaining({
 				agents: expect.arrayContaining(["codex"]),
 				scope: "user",
@@ -275,14 +297,14 @@ describe("init command plugin installation", () => {
 
 		expect(addMarketplaceMock).not.toHaveBeenCalled();
 		expect(installPluginMock).not.toHaveBeenCalled();
-		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+		expect(installAgentPluginForAgentsMock).toHaveBeenLastCalledWith(
 			expect.objectContaining({
 				agents: expect.arrayContaining(["gemini", "cursor"]),
 			}),
 		);
 	});
 
-	it("skips scope prompt and install when plugin already installed at user scope", async () => {
+	it("passes selected agents to agent-plugin even when adapter detection would find an existing install", async () => {
 		listPluginsMock.mockImplementation(async () => [
 			{ name: "agent-validator", scope: "user" },
 		]);
@@ -293,9 +315,32 @@ describe("init command plugin installation", () => {
 		await program.parseAsync(["node", "test", "init"]);
 
 		const output = logs.join("\n");
-		expect(output).toContain("already installed at user scope");
 		expect(addMarketplaceMock).not.toHaveBeenCalled();
 		expect(installPluginMock).not.toHaveBeenCalled();
+		expect(output).not.toContain("already installed at user scope");
+		expect(installAgentPluginForAgentsMock).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				agents: ["claude"],
+				scope: "user",
+			}),
+		);
+	});
+
+	it("runs agent-plugin dry-run and skips install when confirmation is declined", async () => {
+		selectedDevCliNames = ["claude"];
+		selectedReviewCliNames = ["claude"];
+		confirmAgentPluginInstall = false;
+
+		await program.parseAsync(["node", "test", "init"]);
+
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledTimes(1);
+		expect(installAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: ["claude"],
+				scope: "user",
+				dryRun: true,
+			}),
+		);
 	});
 
 	it("on re-run with existing .validator, delegates to plugin update logic", async () => {

--- a/test/commands/update.test.ts
+++ b/test/commands/update.test.ts
@@ -24,6 +24,9 @@ const updatePluginMock = mock(async (_name: string) => ({ success: true }));
 
 const addMarketplaceMock = mock(async () => ({ success: true }));
 const installPluginMock = mock(async (_scope: string) => ({ success: true }));
+const updateAgentPluginForAgentsMock = mock(
+	(_opts: { agents: string[]; scope?: "project" | "user"; yes?: boolean }) => {},
+);
 
 // Cursor adapter spies — spy on prototype methods instead of using mock.module so
 // the cursor.js module registration is not replaced (which would leak into other test
@@ -39,6 +42,15 @@ mock.module("../../src/plugin/claude-cli.js", () => ({
 	listPlugins: () => listPluginsMock(),
 	updateMarketplace: (name: string) => updateMarketplaceMock(name),
 	updatePlugin: (name: string) => updatePluginMock(name),
+}));
+
+mock.module("../../src/plugin/agent-plugin-cli.js", () => ({
+	installAgentPluginForAgents: () => {},
+	updateAgentPluginForAgents: (opts: {
+		agents: string[];
+		scope?: "project" | "user";
+		yes?: boolean;
+	}) => updateAgentPluginForAgentsMock(opts),
 }));
 
 const { registerUpdateCommand } = await import("../../src/commands/update.js");
@@ -74,6 +86,7 @@ describe("update command", () => {
 		updatePluginMock.mockClear();
 		addMarketplaceMock.mockClear();
 		installPluginMock.mockClear();
+		updateAgentPluginForAgentsMock.mockClear();
 
 		// Set up prototype spies with default implementations
 		cursorDetectPluginSpy = spyOn(
@@ -138,15 +151,13 @@ describe("update command", () => {
 		expect(updateMarketplaceMock).toHaveBeenCalledTimes(1);
 		expect(updatePluginMock).toHaveBeenCalledTimes(1);
 		expect(logs.join("\n")).toContain("project scope");
-		const updated = await fs.readFile(
-			path.join(testDir, ".agents", "skills", "validator-help", "SKILL.md"),
-			"utf-8",
+		expect(updateAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: expect.arrayContaining(["claude", "codex"]),
+				scope: "project",
+				yes: true,
+			}),
 		);
-		const source = await fs.readFile(
-			path.join(originalCwd, "skills", "validator-help", "SKILL.md"),
-			"utf-8",
-		);
-		expect(updated).toBe(source);
 	});
 
 	it("updates global Codex skills when only global marker exists", async () => {
@@ -169,18 +180,16 @@ describe("update command", () => {
 
 		await runPluginUpdate();
 
-		const updated = await fs.readFile(
-			path.join(homeDir, ".agents", "skills", "validator-status", "SKILL.md"),
-			"utf-8",
+		expect(updateAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: expect.arrayContaining(["claude", "codex"]),
+				scope: "user",
+				yes: true,
+			}),
 		);
-		const source = await fs.readFile(
-			path.join(originalCwd, "skills", "validator-status", "SKILL.md"),
-			"utf-8",
-		);
-		expect(updated).toBe(source);
 	});
 
-	it("prefers local Codex skills when both local and global markers exist", async () => {
+	it("updates Codex through agent-plugin when local and global markers exist", async () => {
 		listPluginsMock.mockImplementationOnce(async () => [
 			{ name: "agent-validator", scope: "project", projectPath: testDir },
 			{ name: "agent-validator", scope: "user" },
@@ -208,20 +217,13 @@ describe("update command", () => {
 
 		await runPluginUpdate();
 
-		const localUpdated = await fs.readFile(
-			path.join(testDir, ".agents", "skills", "validator-check", "SKILL.md"),
-			"utf-8",
+		expect(updateAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: expect.arrayContaining(["claude", "codex"]),
+				scope: "project",
+				yes: true,
+			}),
 		);
-		const globalUpdated = await fs.readFile(
-			path.join(homeDir, ".agents", "skills", "validator-check", "SKILL.md"),
-			"utf-8",
-		);
-		const source = await fs.readFile(
-			path.join(originalCwd, "skills", "validator-check", "SKILL.md"),
-			"utf-8",
-		);
-		expect(localUpdated).toBe(source);
-		expect(globalUpdated).toBe("global old");
 	});
 
 	it("prints manual update instructions when update fails", async () => {
@@ -287,7 +289,7 @@ describe("update command", () => {
 		expect(output).toContain("reinstalling");
 	});
 
-	it("fails when no Claude plugin and no Cursor plugin are installed", async () => {
+	it("fails when no Claude, Cursor, or Codex install is detected", async () => {
 		listPluginsMock.mockImplementationOnce(async () => []);
 		// cursorDetectPluginSpy already returns null by default
 
@@ -296,6 +298,26 @@ describe("update command", () => {
 		);
 		expect(updateMarketplaceMock).not.toHaveBeenCalled();
 		expect(cursorUpdatePluginSpy).not.toHaveBeenCalled();
+	});
+
+	it("updates Codex fallback when only Codex skills are installed", async () => {
+		listPluginsMock.mockImplementationOnce(async () => []);
+		await fs.mkdir(path.join(homeDir, ".agents", "skills", "validator-run"), {
+			recursive: true,
+		});
+
+		await runPluginUpdate();
+
+		expect(updateMarketplaceMock).not.toHaveBeenCalled();
+		expect(updatePluginMock).not.toHaveBeenCalled();
+		expect(cursorUpdatePluginSpy).not.toHaveBeenCalled();
+		expect(updateAgentPluginForAgentsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agents: ["codex"],
+				scope: "user",
+				yes: true,
+			}),
+		);
 	});
 
 	it("skips Claude update and updates Cursor when only Cursor is installed", async () => {

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -64,7 +64,7 @@ export async function spawnValidator(
 		timeoutMs?: number;
 	},
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-	const proc = Bun.spawn(["node", DIST_BIN, ...args], {
+	const proc = Bun.spawn([process.execPath, DIST_BIN, ...args], {
 		cwd: opts.cwd,
 		stdout: "pipe",
 		stderr: "pipe",

--- a/test/integration/init-e2e.test.ts
+++ b/test/integration/init-e2e.test.ts
@@ -10,7 +10,9 @@ import {
 } from "./helpers.js";
 
 let tempDir: string;
+let homeDir: string;
 let stubBinDir: string;
+let agentPluginLog: string;
 let initResult: { exitCode: number; stdout: string; stderr: string };
 let canRun: boolean;
 
@@ -22,13 +24,40 @@ beforeAll(async () => {
 	stubBinDir = stub.binDir;
 
 	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "validator-init-e2e-"));
+	homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "validator-init-home-"));
+	agentPluginLog = path.join(tempDir, "agent-plugin-calls.jsonl");
+	const agentPluginPath = path.join(
+		homeDir,
+		"codagent",
+		"agent-plugin",
+		"dist",
+		"index.js",
+	);
+	await fs.mkdir(path.dirname(agentPluginPath), { recursive: true });
+	await fs.writeFile(
+		agentPluginPath,
+		[
+			"#!/usr/bin/env node",
+			'import fs from "node:fs";',
+			"const log = process.env.AGENT_PLUGIN_STUB_LOG;",
+			"if (log) fs.appendFileSync(log, `${JSON.stringify(process.argv.slice(2))}\\n`);",
+			"process.exit(0);",
+			"",
+		].join("\n"),
+	);
 	await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
 	await fs.writeFile(path.join(tempDir, "src", "index.ts"), "export {};\n");
 	await initGitRepo(tempDir);
 
 	initResult = await spawnValidator(["init", "--yes"], {
 		cwd: tempDir,
-		env: { ...process.env, PATH: `${stubBinDir}:${process.env.PATH}` },
+		env: {
+			...process.env,
+			AGENT_PLUGIN_BIN: agentPluginPath,
+			AGENT_PLUGIN_STUB_LOG: agentPluginLog,
+			HOME: homeDir,
+			PATH: `${stubBinDir}:${path.dirname(process.execPath)}:/usr/bin:/bin:/usr/sbin:/sbin`,
+		},
 	});
 }, 30_000);
 
@@ -38,6 +67,9 @@ afterAll(async () => {
 	}
 	if (stubBinDir) {
 		await fs.rm(stubBinDir, { recursive: true, force: true }).catch(() => {});
+	}
+	if (homeDir) {
+		await fs.rm(homeDir, { recursive: true, force: true }).catch(() => {});
 	}
 });
 
@@ -72,5 +104,29 @@ describe("agent-validator init (E2E)", () => {
 			"utf-8",
 		);
 		expect(gitignore).toContain("validator_logs");
+	});
+
+	it("should dry-run agent-plugin before installing with --yes", async () => {
+		if (!canRun) return;
+		const calls = (await fs.readFile(agentPluginLog, "utf-8"))
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line));
+		expect(calls).toEqual([
+			[
+				"add",
+				"Codagent-AI/agent-validator",
+				"--agent",
+				"claude",
+				"--dry-run",
+			],
+			[
+				"add",
+				"Codagent-AI/agent-validator",
+				"--agent",
+				"claude",
+				"--yes",
+			],
+		]);
 	});
 });

--- a/test/plugin/agent-plugin-cli.test.ts
+++ b/test/plugin/agent-plugin-cli.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as childProcess from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+describe("agent-plugin-cli", () => {
+	const originalAgentPluginBin = process.env.AGENT_PLUGIN_BIN;
+
+	afterEach(() => {
+		process.env.AGENT_PLUGIN_BIN = originalAgentPluginBin;
+	});
+
+	it("runs the bundled agent-plugin dependency by default", async () => {
+		delete process.env.AGENT_PLUGIN_BIN;
+		const spy = spyOn(childProcess, "execFileSync").mockReturnValue(
+			"" as string & Buffer,
+		);
+		const packageJson = require.resolve("agent-plugin/package.json");
+		const expectedBin = path.join(path.dirname(packageJson), "dist", "index.js");
+
+		const { runAgentPlugin } = await import(
+			"../../src/plugin/agent-plugin-cli.js"
+		);
+		runAgentPlugin(["add", "Codagent-AI/agent-validator", "--dry-run"]);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy.mock.calls[0][0]).toBe(process.execPath);
+		expect(spy.mock.calls[0][1]).toEqual([
+			expectedBin,
+			"add",
+			"Codagent-AI/agent-validator",
+			"--dry-run",
+		]);
+
+		spy.mockRestore();
+	});
+
+	it("honors AGENT_PLUGIN_BIN for local development overrides", async () => {
+		const overrideBin = path.join(
+			process.cwd(),
+			"tmp",
+			"agent-plugin",
+			"dist",
+			"index.js",
+		);
+		process.env.AGENT_PLUGIN_BIN = overrideBin;
+		const spy = spyOn(childProcess, "execFileSync").mockReturnValue(
+			"" as string & Buffer,
+		);
+
+		const { runAgentPlugin } = await import(
+			"../../src/plugin/agent-plugin-cli.js"
+		);
+		runAgentPlugin(["update", "agent-validator"]);
+
+		expect(spy.mock.calls[0][1]).toEqual([
+			overrideBin,
+			"update",
+			"agent-validator",
+		]);
+
+		spy.mockRestore();
+	});
+});

--- a/test/skills/frontmatter.test.ts
+++ b/test/skills/frontmatter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+async function readSkill(name: string): Promise<string> {
+	return fs.readFile(path.join(process.cwd(), "skills", name, "SKILL.md"), "utf-8");
+}
+
+describe("validator skill invocation policy", () => {
+	it("allows model invocation for explicit full validator requests only", async () => {
+		const skill = await readSkill("validator-run");
+
+		expect(skill).toContain("disable-model-invocation: false");
+		expect(skill).toContain("Activates only for explicit full-validator requests");
+		expect(skill).toContain("run the gauntlet");
+		expect(skill).toContain("Do not choose this skill merely because a coding task was completed");
+	});
+
+	it("allows model invocation for explicit checks-only requests", async () => {
+		const skill = await readSkill("validator-check");
+
+		expect(skill).toContain("disable-model-invocation: false");
+		expect(skill).toContain("checks only");
+		expect(skill).toContain("without AI reviews");
+		expect(skill).toContain('Do not choose this skill for generic "run the validator"');
+	});
+
+	it("restricts validator commit to validator-aware commit requests", async () => {
+		const skill = await readSkill("validator-commit");
+
+		expect(skill).toContain("disable-model-invocation: false");
+		expect(skill).toContain("Excludes plain commit requests");
+		expect(skill).toContain("Do not choose this skill for a plain \"commit\"");
+	});
+});

--- a/test/unit/newsletter-metrics.test.ts
+++ b/test/unit/newsletter-metrics.test.ts
@@ -210,4 +210,36 @@ describe('newsletter metrics script', () => {
     expect(telemetryCombo?.executions).toBe(1);
     expect(unknownCombo?.executions).toBe(1);
   });
+
+  it('reuses telemetry model hints for multiple review gates in the same cycle', async () => {
+    const repo = await writeRepo(
+      'telemetry-same-cycle',
+      `[2026-05-01T10:00:00.000] RUN_START mode=full files_changed=1 gates=2
+[2026-05-01T10:00:01.000] TELEMETRY adapter=codex model=from-telemetry
+[2026-05-01T10:00:10.000] GATE_RESULT review:.:code-quality cli=codex status=pass duration=10.0s violations=0
+[2026-05-01T10:00:11.000] GATE_RESULT review:.:security-and-errors cli=codex status=pass duration=8.0s violations=0
+[2026-05-01T10:00:11.100] RUN_END status=pass fixed=0 skipped=0 failed=0 iterations=1 duration=11.1s
+`,
+      undefined,
+      { model: null },
+    );
+
+    const report = await buildMetricsReport({
+      sources: [repo],
+      since: '2026-05-01',
+      until: '2026-05-01',
+      days: 30,
+      format: 'markdown',
+      modelOverrides: new Map(),
+    });
+
+    const telemetryCombos = report.combined.filter(
+      (item) => item.model === 'from-telemetry',
+    );
+    expect(telemetryCombos).toHaveLength(2);
+    expect(telemetryCombos.map((item) => item.reviewer).sort()).toEqual([
+      'code-quality',
+      'security-and-errors',
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- Add `agent-plugin` as the installer/updater dependency and route init installs through its CLI wrapper.
- Delegate fallback skill installation for Codex and other non-native agents to `agent-plugin` instead of copying local skill files.
- Add Docker smoke/E2E scripts that install Codex, Claude Code, and npm `@codagent-ai/agent-plugin`, with `test:e2e` covering the real Docker init path.
- Fix newsletter metrics telemetry attribution so one telemetry model hint applies to every review result in the same validator cycle.

## Validation

- `bun test test/plugin/agent-plugin-cli.test.ts test/integration/init-e2e.test.ts`
- `bun test test/commands/init-prompts.test.ts test/unit/newsletter-metrics.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test:e2e`
- `agent-validate run` -> Passed
