### PR TITLE
Release v1.11.1 with agent-plugin update fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "agent-validator",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "source": "./",
       "description": "A configurable feedback loop runner for AI-assisted development workflows.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [#133](https://github.com/Codagent-AI/agent-validator/pull/133) Add Cursor adapter coverage to the eval harness, Composer-2 evaluation configs, and the April 2026 evaluation report.
 
-- [#136](https://github.com/Codagent-AI/agent-validator/pull/136) Update the init flow to delegate skill and plugin installation to `agent-plugin`, support explicit development agent selection, and improve local AI review setup.
+- [#136](https://github.com/Codagent-AI/agent-validator/pull/136) Update the init flow to delegate skill and plugin installation to `agent-plugin`, support explicit development agent selection, improve local AI review setup, and use the latest bundled `agent-plugin` update behavior.
 
 ## 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-validator
 
+## 1.11.1
+
+### Patch Changes
+
+- [#137](https://github.com/Codagent-AI/agent-validator/pull/137) Update the bundled `agent-plugin` dependency to 0.1.3 and use the canonical repository source for plugin updates.
+
 ## 1.11.0
 
 ### Minor Changes

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.2.1",
         "@logtape/logtape": "^2.0.2",
-        "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.1",
+        "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.2",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "gray-matter": "^4.0.3",
@@ -139,7 +139,7 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
 
-    "agent-plugin": ["@codagent-ai/agent-plugin@0.1.1", "", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-fP8DCWOXYpvG9RlDrIUO9UXgtyDWzCFI1ScgjmErr9nqgMAgWOEwCZxDqU4OU3gK/GiyfmshkyYVG3Z4NW1Hig=="],
+    "agent-plugin": ["@codagent-ai/agent-plugin@0.1.2", "", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-VS7+k422OCe+NbcplHZiVIhUk6as8x5H70roQDysPboYdwTnQmbBQ/WPA5CagB/Ou5wCRTtNG/WYcWv7EvdTlg=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.2.1",
         "@logtape/logtape": "^2.0.2",
-        "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.2",
+        "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.3",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "gray-matter": "^4.0.3",
@@ -139,7 +139,7 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
 
-    "agent-plugin": ["@codagent-ai/agent-plugin@0.1.2", "", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-VS7+k422OCe+NbcplHZiVIhUk6as8x5H70roQDysPboYdwTnQmbBQ/WPA5CagB/Ou5wCRTtNG/WYcWv7EvdTlg=="],
+    "agent-plugin": ["@codagent-ai/agent-plugin@0.1.3", "", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-gHSN1JeuKJ3tWO7JLTznpCgfhNdAXp/17pVQyX1vK0SpCJGrgbO2SBsJmLB2ykd0WoofMDfIjYc8V6RKKCkupw=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -74,7 +74,7 @@ This command:
 4. If Copilot plugin found → re-runs `copilot plugin install` to update
 5. Detects where the Cursor plugin is installed (file-system check)
 6. If Cursor plugin found → re-copies plugin assets from the npm package
-7. Refreshes Codex skills if installed (checksum-based)
+7. Delegates installed agent plugin and skill refreshes to `agent-plugin update Codagent-AI/agent-validator`
 
 ### Scope Detection
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -395,7 +395,7 @@ Updates installed plugins and skills for all supported adapters.
 - If Claude plugin found → runs `claude plugin marketplace update` followed by `claude plugin update`
 - Detects where the Cursor plugin is installed (file-system check for `.cursor/plugins/agent-validator/`)
 - If Cursor plugin found → re-copies plugin assets from the npm package (always overwrite)
-- Refreshes Codex skills if installed (using checksum comparison)
+- Delegates installed agent plugin and skill refreshes to `agent-plugin update Codagent-AI/agent-validator`
 - If no plugins are found at all, exits with an error suggesting `agent-validator init`
 
 ### `agent-validator update-review`

--- a/openspec/specs/plugin-update/spec.md
+++ b/openspec/specs/plugin-update/spec.md
@@ -61,12 +61,12 @@ The `update` command SHALL keep supporting direct updates for existing Claude an
 
 ### Requirement: Agent-plugin update delegation
 
-After detecting installed integrations, `update` SHALL call `agent-plugin update agent-validator` for the agents represented by those integrations. It SHALL pass `--yes`, one `--agent` option for each detected target, and `--project` only when the selected update scope is project/local.
+After detecting installed integrations, `update` SHALL call `agent-plugin update Codagent-AI/agent-validator` for the agents represented by those integrations. It SHALL pass `--yes`, one `--agent` option for each detected target, and `--project` only when the selected update scope is project/local.
 
 #### Scenario: Detected agents are delegated to agent-plugin
 - **GIVEN** Claude, Cursor, and Codex integrations are detected
 - **WHEN** update reaches the centralized update step
-- **THEN** update SHALL invoke `agent-plugin update agent-validator`
+- **THEN** update SHALL invoke `agent-plugin update Codagent-AI/agent-validator`
 - **AND** SHALL pass `--agent claude`, `--agent cursor`, and `--agent codex`
 - **AND** SHALL pass `--yes`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
-    "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.2",
+    "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.3",
     "@logtape/logtape": "^2.0.2",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
-    "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.1",
+    "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.2",
     "@logtape/logtape": "^2.0.2",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",

--- a/src/plugin/agent-plugin-cli.ts
+++ b/src/plugin/agent-plugin-cli.ts
@@ -45,7 +45,7 @@ export function updateAgentPluginForAgents(opts: {
   scope?: 'user' | 'project';
   yes?: boolean;
 }): void {
-  const args = ['update', 'agent-validator'];
+  const args = ['update', AGENT_PLUGIN_SOURCE];
   for (const agent of opts.agents) {
     args.push('--agent', toAgentPluginName(agent));
   }

--- a/test/plugin/agent-plugin-cli.test.ts
+++ b/test/plugin/agent-plugin-cli.test.ts
@@ -53,12 +53,46 @@ describe("agent-plugin-cli", () => {
 		const { runAgentPlugin } = await import(
 			"../../src/plugin/agent-plugin-cli.js"
 		);
-		runAgentPlugin(["update", "agent-validator"]);
+		runAgentPlugin(["update", "Codagent-AI/agent-validator"]);
 
 		expect(spy.mock.calls[0][1]).toEqual([
 			overrideBin,
 			"update",
-			"agent-validator",
+			"Codagent-AI/agent-validator",
+		]);
+
+		spy.mockRestore();
+	});
+
+	it("updates by canonical repository source", async () => {
+		const spy = spyOn(childProcess, "execFileSync").mockReturnValue(
+			"" as string & Buffer,
+		);
+
+		const { updateAgentPluginForAgents } = await import(
+			"../../src/plugin/agent-plugin-cli.js"
+		);
+		updateAgentPluginForAgents({
+			agents: ["claude", "github-copilot", "codex"],
+			scope: "project",
+			yes: true,
+		});
+
+		const firstCall = spy.mock.calls[0];
+		if (!firstCall) throw new Error("Expected agent-plugin to be executed");
+		const args = firstCall[1];
+		if (!args) throw new Error("Expected agent-plugin args");
+		expect(args.slice(1)).toEqual([
+			"update",
+			"Codagent-AI/agent-validator",
+			"--agent",
+			"claude",
+			"--agent",
+			"copilot",
+			"--agent",
+			"codex",
+			"--project",
+			"--yes",
 		]);
 
 		spy.mockRestore();


### PR DESCRIPTION
## Summary

- fix agent-plugin update delegation to use the canonical Codagent-AI/agent-validator source
- bump the bundled agent-plugin dependency to 0.1.3
- release Agent Validator v1.11.1 and sync plugin manifests

## Validation

- bun test test/plugin/agent-plugin-cli.test.ts test/commands/update.test.ts
- bun run build:local
- bun run test
- bun run test:e2e
- agent-validate run