### PR TITLE
fix: disclose claude reviewer billing in init prompt

### DIFF
--- a/.agents/commands/release.md
+++ b/.agents/commands/release.md
@@ -1,0 +1,1 @@
+../../.claude/commands/release.md

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "agent-validator",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "source": "./",
       "description": "A configurable feedback loop runner for AI-assisted development workflows.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#138](https://github.com/Codagent-AI/agent-validator/pull/138) Disclose that Claude reviewer usage is billed to the user during init, and expose the release command to Codex agents for release preparation.
+- [#138](https://github.com/Codagent-AI/agent-validator/pull/138) Disclose that Claude reviewer usage is billed to the user during init, expose the release command to Codex agents for release preparation, and harden Copilot plugin tests against cross-file mock leakage.
 
 ## 1.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-validator
 
+## 1.11.2
+
+### Patch Changes
+
+- [#138](https://github.com/Codagent-AI/agent-validator/pull/138) Disclose that Claude reviewer usage is billed to the user during init, and expose the release command to Codex agents for release preparation.
+
 ## 1.11.1
 
 ### Patch Changes

--- a/openspec/specs/init-config/spec.md
+++ b/openspec/specs/init-config/spec.md
@@ -137,6 +137,11 @@ The `init` command SHALL present interactive prompts for development CLI selecti
 - **THEN** init SHALL NOT show the review CLI multi-select prompt
 - **AND** init SHALL NOT ask how many review CLIs should run on every review
 
+#### Scenario: Claude review CLI shows programmatic billing disclosure
+- **WHEN** the review CLI multi-select prompt is rendered
+- **AND** `claude` is an available option
+- **THEN** the `claude` option SHALL include a visible disclosure that programmatic use may be billed at API rates
+
 #### Scenario: Review CLIs set default_preference
 - **GIVEN** the user selects `claude` and `codex` as review CLIs
 - **WHEN** the config is generated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",

--- a/src/cli-adapters/github-copilot.ts
+++ b/src/cli-adapters/github-copilot.ts
@@ -3,10 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { getCategoryLogger } from '../output/app-logger.js';
-import {
-  detectPlugin as detectCopilotPlugin,
-  installPlugin as installCopilotPlugin,
-} from '../plugin/copilot-cli.js';
+import * as copilotCli from '../plugin/copilot-cli.js';
 import { SAFE_MODEL_ID_PATTERN } from './model-resolution.js';
 import type { CLIAdapter } from './shared.js';
 
@@ -216,14 +213,14 @@ export class GitHubCopilotAdapter implements CLIAdapter {
   }
 
   async detectPlugin(_projectRoot: string): Promise<'user' | 'project' | null> {
-    return detectCopilotPlugin();
+    return copilotCli.detectPlugin();
   }
 
   async installPlugin(
     _scope: 'user' | 'project',
     _projectRoot?: string,
   ): Promise<{ success: boolean; error?: string }> {
-    const result = await installCopilotPlugin();
+    const result = await copilotCli.installPlugin();
     if (!result.success) {
       return { success: false, error: result.stderr };
     }

--- a/src/commands/init-prompts.ts
+++ b/src/commands/init-prompts.ts
@@ -7,6 +7,13 @@ function toSortedChoices(names: string[]): { name: string; value: string }[] {
     .map((name) => ({ name, value: name }));
 }
 
+function reviewLabel(name: string, recommended: Set<string>): string {
+  if (recommended.has(name)) return `${name} (recommended)`;
+  if (name === 'claude')
+    return `${name} (programmatic use may be billed at API rates)`;
+  return name;
+}
+
 function toReviewChoices(names: string[]): { name: string; value: string }[] {
   const recommended = new Set(['codex', 'github-copilot']);
   return [...names]
@@ -17,7 +24,7 @@ function toReviewChoices(names: string[]): { name: string; value: string }[] {
       return a.localeCompare(b);
     })
     .map((name) => ({
-      name: recommended.has(name) ? `${name} (recommended)` : name,
+      name: reviewLabel(name, recommended),
       value: name,
     }));
 }

--- a/src/plugin/copilot-cli.ts
+++ b/src/plugin/copilot-cli.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import * as childProcess from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -10,7 +10,7 @@ export interface CopilotCliResult {
 
 export async function installPlugin(): Promise<CopilotCliResult> {
   try {
-    execFileSync(
+    childProcess.execFileSync(
       'copilot',
       ['plugin', 'install', 'Codagent-AI/agent-validator'],
       {

--- a/test/cli-adapters/copilot-plugin.test.ts
+++ b/test/cli-adapters/copilot-plugin.test.ts
@@ -12,46 +12,41 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-
-// Mock copilot-cli module before importing the adapter
-const mockInstallPlugin = mock(() =>
-	Promise.resolve({ success: true } as { success: boolean; stderr?: string }),
-);
-const mockDetectPlugin = mock(
-	() => Promise.resolve(null) as Promise<"user" | null>,
-);
-
-mock.module("../../src/plugin/copilot-cli.js", () => ({
-	installPlugin: mockInstallPlugin,
-	detectPlugin: mockDetectPlugin,
-}));
+import * as copilotCli from "../../src/plugin/copilot-cli.js";
 
 describe("GitHubCopilotAdapter plugin lifecycle", () => {
 	// biome-ignore lint/suspicious/noExplicitAny: dynamic import typing
 	let adapter: any;
+	let installPluginSpy: ReturnType<typeof spyOn>;
+	let detectPluginSpy: ReturnType<typeof spyOn>;
 
 	beforeEach(async () => {
+		installPluginSpy = spyOn(copilotCli, "installPlugin").mockImplementation(() =>
+			Promise.resolve({ success: true }),
+		);
+		detectPluginSpy = spyOn(copilotCli, "detectPlugin").mockImplementation(() =>
+			Promise.resolve(null),
+		);
 		const { GitHubCopilotAdapter } = await import(
 			"../../src/cli-adapters/github-copilot.js"
 		);
 		adapter = new GitHubCopilotAdapter();
-		mockInstallPlugin.mockReset();
-		mockDetectPlugin.mockReset();
-		mockInstallPlugin.mockImplementation(() =>
-			Promise.resolve({ success: true }),
-		);
-		mockDetectPlugin.mockImplementation(() => Promise.resolve(null));
+	});
+
+	afterEach(() => {
+		installPluginSpy.mockRestore();
+		detectPluginSpy.mockRestore();
 	});
 
 	describe("detectPlugin", () => {
 		it("returns null when plugin is not installed", async () => {
-			mockDetectPlugin.mockImplementation(() => Promise.resolve(null));
+			detectPluginSpy.mockImplementation(() => Promise.resolve(null));
 			const result = await adapter.detectPlugin("/some/project");
 			expect(result).toBeNull();
 		});
 
 		it("returns 'user' when plugin is detected", async () => {
-			mockDetectPlugin.mockImplementation(() => Promise.resolve("user" as const));
+			detectPluginSpy.mockImplementation(() => Promise.resolve("user" as const));
 			const result = await adapter.detectPlugin("/some/project");
 			expect(result).toBe("user");
 		});
@@ -61,17 +56,17 @@ describe("GitHubCopilotAdapter plugin lifecycle", () => {
 		it("returns success when install succeeds", async () => {
 			const result = await adapter.installPlugin("user");
 			expect(result).toEqual({ success: true });
-			expect(mockInstallPlugin).toHaveBeenCalledTimes(1);
+			expect(installPluginSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it("accepts scope parameter for interface compatibility but delegates to copilot-cli", async () => {
 			await adapter.installPlugin("project");
 			// Copilot always installs to user scope, but the adapter accepts scope for compatibility
-			expect(mockInstallPlugin).toHaveBeenCalledTimes(1);
+			expect(installPluginSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it("returns failure with error when install fails", async () => {
-			mockInstallPlugin.mockImplementation(() =>
+			installPluginSpy.mockImplementation(() =>
 				Promise.resolve({
 					success: false,
 					stderr: "install error",
@@ -89,7 +84,7 @@ describe("GitHubCopilotAdapter plugin lifecycle", () => {
 		it("delegates to installPlugin (re-install overwrites)", async () => {
 			const result = await adapter.updatePlugin!("user");
 			expect(result).toEqual({ success: true });
-			expect(mockInstallPlugin).toHaveBeenCalledTimes(1);
+			expect(installPluginSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/test/commands/init-prompts.test.ts
+++ b/test/commands/init-prompts.test.ts
@@ -161,7 +161,7 @@ describe("promptReviewCLIs", () => {
 		expect(checkboxCalls[0]?.choices?.map((choice) => choice.name)).toEqual([
 			"codex (recommended)",
 			"github-copilot (recommended)",
-			"claude",
+			"claude (programmatic use may be billed at API rates)",
 			"opencode",
 		]);
 		expect(checkboxCalls[0]?.choices?.map((choice) => choice.value)).toEqual([

--- a/test/gates/skip-passed-reviews.test.ts
+++ b/test/gates/skip-passed-reviews.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
 	findPreviousFailures,
 	type PreviousFailuresResult,
 } from "../../src/utils/log-parser.js";
 
-const TEST_DIR = path.join(import.meta.dir, "../../.test-skip-passed");
+const TEST_DIR = path.join(
+	os.tmpdir(),
+	`agent-validator-test-skip-passed-${process.pid}`,
+);
 
 describe("Skip Passed Reviews", () => {
 	beforeEach(async () => {

--- a/test/gates/skip-passed-reviews.test.ts
+++ b/test/gates/skip-passed-reviews.test.ts
@@ -7,26 +7,24 @@ import {
 	type PreviousFailuresResult,
 } from "../../src/utils/log-parser.js";
 
-const TEST_DIR = path.join(
-	os.tmpdir(),
-	`agent-validator-test-skip-passed-${process.pid}`,
-);
-
 describe("Skip Passed Reviews", () => {
+	let testDir: string;
+
 	beforeEach(async () => {
-		await fs.rm(TEST_DIR, { recursive: true, force: true });
-		await fs.mkdir(TEST_DIR, { recursive: true });
+		testDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "agent-validator-test-skip-passed-"),
+		);
 	});
 
 	afterEach(async () => {
-		await fs.rm(TEST_DIR, { recursive: true, force: true });
+		await fs.rm(testDir, { recursive: true, force: true });
 	});
 
 	describe("findPreviousFailures with passedSlots", () => {
 		it("returns correct passed slots with iteration numbers and adapter", async () => {
 			// Create a passed review log with @1 pattern
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_code-quality_claude@1.2.json"),
+				path.join(testDir, "review_src_code-quality_claude@1.2.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -37,7 +35,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -55,7 +53,7 @@ describe("Skip Passed Reviews", () => {
 		it("Scenario 1: num_reviews=2 with 1 pass + 1 fail returns only failed slot", async () => {
 			// Slot 1 passed in iteration 1
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.1.json"),
+				path.join(testDir, "review_src_quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -67,7 +65,7 @@ describe("Skip Passed Reviews", () => {
 
 			// Slot 2 failed in iteration 1
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_gemini@2.1.json"),
+				path.join(testDir, "review_src_quality_gemini@2.1.json"),
 				JSON.stringify({
 					adapter: "gemini",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -86,7 +84,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -106,7 +104,7 @@ describe("Skip Passed Reviews", () => {
 		it("Scenario 2: slot skipped across multiple iterations", async () => {
 			// Slot 1 passed in iteration 1
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.1.json"),
+				path.join(testDir, "review_src_quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -118,7 +116,7 @@ describe("Skip Passed Reviews", () => {
 
 			// Slot 2 still failing in iteration 3 (latest)
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_gemini@2.3.json"),
+				path.join(testDir, "review_src_quality_gemini@2.3.json"),
 				JSON.stringify({
 					adapter: "gemini",
 					timestamp: "2026-01-24T14:00:00Z",
@@ -137,7 +135,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -155,7 +153,7 @@ describe("Skip Passed Reviews", () => {
 		it("Scenario 3: all slots passed (safety latch scenario)", async () => {
 			// Slot 1 passed in iteration 1
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.1.json"),
+				path.join(testDir, "review_src_quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -167,7 +165,7 @@ describe("Skip Passed Reviews", () => {
 
 			// Slot 2 passed in iteration 2
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_gemini@2.2.json"),
+				path.join(testDir, "review_src_quality_gemini@2.2.json"),
 				JSON.stringify({
 					adapter: "gemini",
 					timestamp: "2026-01-24T13:00:00Z",
@@ -178,7 +176,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -198,7 +196,7 @@ describe("Skip Passed Reviews", () => {
 		it("Scenario 4: num_reviews=1 still runs (invariant check)", async () => {
 			// Single slot passed
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.1.json"),
+				path.join(testDir, "review_src_quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -209,7 +207,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -223,7 +221,7 @@ describe("Skip Passed Reviews", () => {
 		it("Scenario 5: different review gates are independent", async () => {
 			// code-quality gate passed
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_code-quality_claude@1.1.json"),
+				path.join(testDir, "review_src_code-quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -235,7 +233,7 @@ describe("Skip Passed Reviews", () => {
 
 			// security gate failed
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_security_claude@1.1.json"),
+				path.join(testDir, "review_src_security_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -254,7 +252,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -274,7 +272,7 @@ describe("Skip Passed Reviews", () => {
 		it("Scenario 6: adapter changes but slot still tracked by review index", async () => {
 			// Slot 1 passed with claude
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.1.json"),
+				path.join(testDir, "review_src_quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -286,7 +284,7 @@ describe("Skip Passed Reviews", () => {
 
 			// Slot 2 failed with gemini (but could be any adapter)
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_gemini@2.1.json"),
+				path.join(testDir, "review_src_quality_gemini@2.1.json"),
 				JSON.stringify({
 					adapter: "gemini",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -305,7 +303,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -322,7 +320,7 @@ describe("Skip Passed Reviews", () => {
 		it("Scenario 11: slot with no prior log files must run", async () => {
 			// Only slot 1 has logs, slot 2 has no logs yet
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.1.json"),
+				path.join(testDir, "review_src_quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -341,7 +339,7 @@ describe("Skip Passed Reviews", () => {
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -367,12 +365,12 @@ describe("Skip Passed Reviews", () => {
 			};
 
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.2.json"),
+				path.join(testDir, "review_src_quality_claude@1.2.json"),
 				JSON.stringify(skippedJson),
 			);
 
 			const result = (await findPreviousFailures(
-				TEST_DIR,
+				testDir,
 				undefined,
 				true,
 			)) as PreviousFailuresResult;
@@ -385,7 +383,7 @@ describe("Skip Passed Reviews", () => {
 	describe("backwards compatibility", () => {
 		it("findPreviousFailures without includePassedSlots returns array", async () => {
 			await fs.writeFile(
-				path.join(TEST_DIR, "review_src_quality_claude@1.1.json"),
+				path.join(testDir, "review_src_quality_claude@1.1.json"),
 				JSON.stringify({
 					adapter: "claude",
 					timestamp: "2026-01-24T12:00:00Z",
@@ -403,7 +401,7 @@ describe("Skip Passed Reviews", () => {
 				}),
 			);
 
-			const result = await findPreviousFailures(TEST_DIR);
+			const result = await findPreviousFailures(testDir);
 
 			// Should return array (not object with failures/passedSlots)
 			expect(Array.isArray(result)).toBe(true);


### PR DESCRIPTION
## Summary
- Disclose that Claude reviewer usage is billed to the user in the init prompt
- Expose the repository release command to Codex agents via .agents/commands
- Release v1.11.2 with a changelog entry covering PR #138

## Verification
- bun run test
- bun run test:e2e
- agent-validate run