### PR TITLE
fix: allow model invocation for all validator skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "agent-validator",
-      "version": "1.11.2",
+      "version": "1.11.3",
       "source": "./",
       "description": "A configurable feedback loop runner for AI-assisted development workflows.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#139](https://github.com/Codagent-AI/agent-validator/pull/139) Allow model invocation for all shipped validator skills and add regression coverage so future skill frontmatter cannot disable model invocation.
+- [#139](https://github.com/Codagent-AI/agent-validator/pull/139) Allow model invocation for all shipped validator skills, require explicit confirmation before `validator-skip` advances the baseline, and add regression coverage so future skill frontmatter cannot disable model invocation.
 
 ## 1.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-validator
 
+## 1.11.3
+
+### Patch Changes
+
+- [#139](https://github.com/Codagent-AI/agent-validator/pull/139) Allow model invocation for all shipped validator skills and add regression coverage so future skill frontmatter cannot disable model invocation.
+
 ## 1.11.2
 
 ### Patch Changes

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -153,8 +153,8 @@ allowed-tools: Bash
 ---
 ```
 
-- `disable-model-invocation: true` prevents Claude from automatically loading and invoking the skill. The user can still invoke it via `/name`. Use this for workflows that should never be selected by model invocation.
-- `disable-model-invocation: false` allows model invocation. Keep the `description` and invocation policy narrow for side-effecting workflows so agents select them only when the user explicitly asks.
+- `disable-model-invocation: false` allows model invocation. Agent Validator skills use this setting so explicit user requests can invoke them through model skill selection; keep the `description` and invocation policy narrow for side-effecting workflows.
+- Do not set `disable-model-invocation: true` on shipped Agent Validator skills.
 - `user-invocable: false` hides the skill from the `/` autocomplete menu entirely.
 - `allowed-tools` restricts which tools the agent can use during execution
 

--- a/openspec/specs/agent-command/spec.md
+++ b/openspec/specs/agent-command/spec.md
@@ -180,8 +180,8 @@ The system SHALL store canonical distributable skill files under `skills/validat
 #### Scenario: Skill frontmatter format
 - **WHEN** a skill `SKILL.md` file is created
 - **THEN** it SHALL contain YAML frontmatter with `name`, `description`, and `allowed-tools` fields
-- **AND** non-model-invoked validator skills (`validator-status`) SHALL set `disable-model-invocation: true`
-- **AND** `validator-run` and `validator-check` SHALL set `disable-model-invocation: false` so explicit validation requests can invoke them through model skill selection
+- **AND** no shipped validator skill SHALL set `disable-model-invocation: true`
+- **AND** validator skills that declare `disable-model-invocation` SHALL set it to `false` so explicit validation requests can invoke them through model skill selection
 
 #### Scenario: Hyphenated skill invocation
 - **GIVEN** a target agent has installed the `validator-run` skill from the agent-validator plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",

--- a/skills/validator-skip/SKILL.md
+++ b/skills/validator-skip/SKILL.md
@@ -10,6 +10,12 @@ Advance the execution state baseline to the current working tree without running
 
 ## Step 1: Run the skip command
 
+First, require explicit user confirmation before executing the command:
+
+- If the current user request already contains the exact phrase `skip validator`, treat that as confirmation and continue.
+- Otherwise, ask the user to confirm with the exact phrase `skip validator`.
+- Do not run `agent-validate skip` from inferred intent, validator automation, or another skill's cleanup path.
+
 ```bash
 agent-validate skip 2>&1
 ```

--- a/skills/validator-skip/SKILL.md
+++ b/skills/validator-skip/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validator-skip
 description: Advances the validator execution state baseline without running checks for requests such as "skip validator", "advance validator baseline", or "mark current tree as validated without running checks".
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash
 ---
 

--- a/skills/validator-status/SKILL.md
+++ b/skills/validator-status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validator-status
 description: Shows a summary of the most recent validator session for requests such as "show validator status", "summarize last validator run", or "what failed in the last validator session".
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read
 ---
 

--- a/test/skills/frontmatter.test.ts
+++ b/test/skills/frontmatter.test.ts
@@ -46,4 +46,13 @@ describe("validator skill invocation policy", () => {
 			skill.indexOf('Contains "run", "full", or "all gates"'),
 		);
 	});
+
+	it("requires explicit confirmation before skipping validation", async () => {
+		const skill = await readSkill("validator-skip");
+
+		expect(skill).toContain("disable-model-invocation: false");
+		expect(skill).toContain("require explicit user confirmation");
+		expect(skill).toContain("exact phrase `skip validator`");
+		expect(skill).toContain("Do not run `agent-validate skip` from inferred intent");
+	});
 });

--- a/test/skills/frontmatter.test.ts
+++ b/test/skills/frontmatter.test.ts
@@ -7,6 +7,17 @@ async function readSkill(name: string): Promise<string> {
 }
 
 describe("validator skill invocation policy", () => {
+	it("does not disable model invocation for any shipped skill", async () => {
+		const skillsDir = path.join(process.cwd(), "skills");
+		const skillNames = await fs.readdir(skillsDir);
+
+		for (const skillName of skillNames) {
+			const skill = await readSkill(skillName);
+
+			expect(skill).not.toContain("disable-model-invocation: true");
+		}
+	});
+
 	it("allows model invocation for explicit full validator requests only", async () => {
 		const skill = await readSkill("validator-run");
 


### PR DESCRIPTION
## Summary
- Set shipped validator status/skip skills to allow model invocation
- Add regression coverage to reject disabled model invocation in shipped skills
- Require explicit confirmation before validator-skip can advance the validation baseline
- Update the skill guide, active spec, and v1.11.3 changelog for the new policy

## Release
- Bumps agent-validator to 1.11.3
- Syncs Claude and Cursor plugin manifest versions

## Verification
- bun test test/skills/frontmatter.test.ts
- bun run test
- bun run test:e2e
- agent-validate run