### PR TITLE
Fix agent-plugin dependency and formula validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "agent-validator",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "source": "./",
       "description": "A configurable feedback loop runner for AI-assisted development workflows.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT"
 }

--- a/.github/scripts/homebrew-formula.ts
+++ b/.github/scripts/homebrew-formula.ts
@@ -43,6 +43,9 @@ function validateFormulaInput(input: FormulaInput): void {
 	if (!input.tarballUrl.startsWith("https://registry.npmjs.org/agent-validator/-/")) {
 		throw new Error("tarballUrl must be the npm registry tarball URL for agent-validator");
 	}
+	if (input.tarballUrl !== `https://registry.npmjs.org/agent-validator/-/agent-validator-${input.version}.tgz`) {
+		throw new Error("tarballUrl must match version");
+	}
 	if (!/^[a-f0-9]{64}$/.test(input.sha256)) {
 		throw new Error("sha256 must be a lowercase 64-character hex digest");
 	}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#143](https://github.com/Codagent-AI/agent-validator/pull/143) Update the bundled `agent-plugin` dependency to 0.1.4 and harden Homebrew formula version validation so generated formula URLs must match the release version.
+- [#143](https://github.com/Codagent-AI/agent-validator/pull/143) Update the bundled `agent-plugin` dependency to 0.1.4, harden Homebrew formula version validation so generated formula URLs must match the release version, and tighten `/validator-setup` so init-created `.validator/` scaffolds are treated as fresh installs instead of completed prior setups.
 
 ## 1.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-validator
 
+## 1.13.1
+
+### Patch Changes
+
+- [#143](https://github.com/Codagent-AI/agent-validator/pull/143) Update the bundled `agent-plugin` dependency to 0.1.4 and harden Homebrew formula version validation so generated formula URLs must match the release version.
+
 ## 1.13.0
 
 ### Minor Changes

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "agent-validator",
       "dependencies": {
         "@inquirer/prompts": "^8.2.1",
+        "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.4",
         "@logtape/logtape": "^2.0.2",
-        "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.3",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "gray-matter": "^4.0.3",
@@ -139,7 +139,7 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
 
-    "agent-plugin": ["@codagent-ai/agent-plugin@0.1.3", "", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-gHSN1JeuKJ3tWO7JLTznpCgfhNdAXp/17pVQyX1vK0SpCJGrgbO2SBsJmLB2ykd0WoofMDfIjYc8V6RKKCkupw=="],
+    "agent-plugin": ["@codagent-ai/agent-plugin@0.1.4", "", { "dependencies": { "@inquirer/prompts": "^8.2.5", "commander": "^14.0.2", "zod": "^4.3.5" }, "bin": { "agent-plugin": "dist/index.js" } }, "sha512-CwfDayw17rls89rjtxn5lQDYSlFh6nPFLvXSd0vmficf9lkj2mZjnIceiqNBgR0slmUmLz13nMjI+Ll1oCPGKQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.2.1",
-    "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.3",
+    "agent-plugin": "npm:@codagent-ai/agent-plugin@0.1.4",
     "@logtape/logtape": "^2.0.2",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-validator",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A CLI tool for validating AI coding agents",
   "license": "MIT",
   "author": "Paul Caplan",

--- a/skills/validator-setup/SKILL.md
+++ b/skills/validator-setup/SKILL.md
@@ -18,6 +18,14 @@ Read `.validator/config.yml`. If the file does not exist, tell the user to run `
 
 Read the `entry_points` field from `.validator/config.yml`.
 
+Before deciding whether this project is already configured, inspect the git state of `.validator/`:
+
+- If this is a git repo, run `git status --porcelain -- .validator`.
+- If `.validator/` or `.validator/config.yml` is untracked or newly added, treat this as a fresh install even though the directory exists. `agent-validate init` creates the scaffold first; `/validator-setup` still needs to configure checks and entry points.
+- If git is unavailable, the project is not a git repo, or the status is ambiguous, do not claim Agent Validator was previously set up. Ask the user whether this is a new install or an existing configuration they want to modify.
+
+Do not conclude "nothing to do" or "already set up" merely because `.validator/` exists. Only treat the project as an existing setup when the committed config already contains meaningful entry points/checks, or the user confirms it is existing.
+
 **If `entry_points` is empty (`[]`) OR contains only the generated root entry point (`path: "."`) with no `checks`:** This is a fresh setup. Proceed to Step 3 (detect project structure). Preserve any existing `reviews` on that generated root entry point unless the user explicitly reconfigures reviews.
 
 **If `entry_points` is populated:** Show the user a summary of the current configuration:

--- a/test/skills/validator-setup.test.ts
+++ b/test/skills/validator-setup.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+async function readSetupSkill(): Promise<string> {
+	return fs.readFile(
+		path.join(process.cwd(), "skills", "validator-setup", "SKILL.md"),
+		"utf-8",
+	);
+}
+
+describe("validator-setup skill", () => {
+	it("does not treat an init-created .validator directory as an existing setup", async () => {
+		const skill = await readSetupSkill();
+
+		expect(skill).toContain("git status --porcelain -- .validator");
+		expect(skill).toContain(
+			"treat this as a fresh install even though the directory exists",
+		);
+		expect(skill).toContain(
+			"Do not conclude \"nothing to do\" or \"already set up\" merely because `.validator/` exists",
+		);
+	});
+});

--- a/test/unit/homebrew-formula.test.ts
+++ b/test/unit/homebrew-formula.test.ts
@@ -19,4 +19,14 @@ describe("homebrew formula generation", () => {
 		expect(formula).toContain('shell_output("#{bin}/agent-validate --version")');
 		expect(formula).toContain('shell_output("#{bin}/agent-validator --version")');
 	});
+
+	it("rejects a tarball URL that does not match the formula version", () => {
+		expect(() =>
+			buildHomebrewFormula({
+				version: "1.10.0",
+				tarballUrl: "https://registry.npmjs.org/agent-validator/-/agent-validator-1.9.0.tgz",
+				sha256: "a".repeat(64),
+			}),
+		).toThrow("tarballUrl must match version");
+	});
 });


### PR DESCRIPTION
## Summary
- update agent-validator to consume agent-plugin 0.1.4
- harden Homebrew formula input validation and add coverage

## Validation
- agent-validate run: checks passed; review flagged local untracked .claude files, which were excluded from this clone and are not part of the PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation to require exact version URL matching for Homebrew installations.

* **Chores**
  * Bumped package version to 1.13.1 across all plugin manifests.
  * Updated plugin dependency to 0.1.4.

* **Documentation**
  * Enhanced validator setup guidance with clearer instructions for detecting fresh installations versus existing configurations.

* **Tests**
  * Added test coverage for validator setup behavior and installation validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Codagent-AI/agent-validator/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->